### PR TITLE
Add custom entrypoint support for recipe publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,22 @@ version = 4
 
 [[package]]
 name = "adaptive-client-rust"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f0ac947c12043bd33608393db00dc6744370402b89fceb011e3a0ab116204"
+checksum = "fd6020eba2a7cd5a4fc79092df363d7c793d7b4aee8bf637c4f043a3916aa450"
 dependencies = [
  "async-stream",
+ "backon",
+ "bytes",
  "futures",
  "graphql_client",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -28,7 +32,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adpt"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "adaptive-client-rust",
  "anyhow",
@@ -47,6 +51,7 @@ dependencies = [
  "iocraft",
  "keyring",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "slug",
@@ -54,6 +59,7 @@ dependencies = [
  "termwiz",
  "tokio",
  "toml",
+ "typed-path",
  "url",
  "uuid",
  "zip",
@@ -330,6 +336,17 @@ dependencies = [
  "tree-sitter-json",
  "tree-sitter-language",
  "v_htmlescape",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -835,7 +852,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -928,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1214,6 +1231,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2248,7 +2277,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2443,6 +2472,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,7 +2525,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2908,10 +2952,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3053,9 +3097,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3313,7 +3357,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3683,7 +3727,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "adpt"
-version = "0.13.6"
+version = "0.14.0"
 edition = "2024"
 description = "A tool for interacting with the Adaptive platform"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-adaptive-client-rust = "0.14.0"
+adaptive-client-rust = "0.14.1"
 anyhow = "1.0.100"
 async-stream = "0.3"
 futures = "0.3"
-autumnus = { version = "0.7.6", default-features = false, features = ["lang-json"] }
+autumnus = { version = "0.7.6", default-features = false, features = [
+    "lang-json",
+] }
 clap = { version = "4.5.47", features = ["derive", "string"] }
 clap_complete = { version = "4.5.58", features = ["unstable-dynamic"] }
 directories = "6.0.0"
@@ -18,8 +20,18 @@ dotenvy = "0.15.7"
 envy = "0.4.2"
 graphql_client = "0.15.0"
 iocraft = "0.8.0"
-keyring = { version = "3.6.3", features = ["apple-native", "crypto-rust", "sync-secret-service"] }
-reqwest = { version = "0.12.23", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
+keyring = { version = "3.6.3", features = [
+    "apple-native",
+    "crypto-rust",
+    "sync-secret-service",
+] }
+reqwest = { version = "0.12.23", default-features = false, features = [
+    "json",
+    "multipart",
+    "rustls-tls",
+    "stream",
+] }
+reqwest-middleware = "0.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.145"
 slug = "0.1.6"
@@ -30,10 +42,13 @@ toml = "1.0.0"
 url = { version = "2.5.7", features = ["serde"] }
 uuid = { version = "1.18.1", features = ["serde"] }
 zip = { version = "8.4.0", default-features = false, features = ["deflate"] }
-zip-extensions = { version = "0.14.1", default-features = false, features = ["deflate"] }
+zip-extensions = { version = "0.14.1", default-features = false, features = [
+    "deflate",
+] }
 humantime = "2.3.0"
 email_address = "0.2.9"
 clap-markdown = "0.1.5"
+typed-path = "0.12.3"
 
 [package.metadata.generate-rpm]
 assets = [

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -147,6 +147,8 @@ Upload recipe
 * `-p`, `--project <PROJECT>`
 * `-n`, `--name <NAME>` — Recipe name
 * `-k`, `--key <KEY>` — Recipe key
+* `-e`, `--entrypoint <ENTRYPOINT>` — Custom entrypoint file
+* `-c`, `--entrypoint-config <ENTRYPOINT_CONFIG>` — Custom config entrypoint file
 * `-f`, `--force` — Update existing recipe if it exists
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -552,9 +552,19 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     Ok(())
 }
 
-fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>) -> Result<TempPath> {
-    if entrypoint.is_none() && !recipe_dir.as_ref().join("main.py").is_file() {
+fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, entrypoint_config: &Option<String>) -> Result<TempPath> {
+    if let Some(ep) = entrypoint {
+        if !recipe_dir.as_ref().join(ep).is_file() {
+            bail!("Entrypoint file '{ep}' does not exist in recipe directory");
+        }
+    } else if !recipe_dir.as_ref().join("main.py").is_file() {
         bail!("Recipe directory must contain a main.py file, or specify --entrypoint");
+    }
+
+    if let Some(ep) = entrypoint_config {
+        if !recipe_dir.as_ref().join(ep).is_file() {
+            bail!("Config entrypoint file '{ep}' does not exist in recipe directory");
+        }
     }
 
     let tmp_file = NamedTempFile::new()?;
@@ -604,7 +614,7 @@ async fn publish_recipe<P: AsRef<Path>>(
         }
 
         let recipe_path: Box<dyn AsRef<Path> + Send> = if recipe.as_ref().is_dir() {
-            Box::new(zip_recipe_dir(&recipe, &entrypoint)?)
+            Box::new(zip_recipe_dir(&recipe, &entrypoint, &entrypoint_config)?)
         } else {
             Box::new(recipe.as_ref().to_path_buf())
         };
@@ -625,7 +635,7 @@ async fn publish_recipe<P: AsRef<Path>>(
         (response.id, response.key)
     } else {
         let response = if recipe.as_ref().is_dir() {
-            let recipe = zip_recipe_dir(recipe, &entrypoint)?;
+            let recipe = zip_recipe_dir(recipe, &entrypoint, &entrypoint_config)?;
             client
                 .publish_recipe(project, &name, &key, &recipe, entrypoint, entrypoint_config)
                 .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,12 @@ enum Commands {
         /// Recipe key
         #[arg(short, long)]
         key: Option<String>,
+        /// Custom entrypoint file (relative path within directory)
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        entrypoint: Option<String>,
+        /// Custom config entrypoint file (relative path within directory)
+        #[arg(short = 'c', long, value_hint = ValueHint::FilePath)]
+        entrypoint_config: Option<String>,
         /// Update existing recipe if it exists
         #[arg(short, long)]
         force: bool,
@@ -332,8 +338,10 @@ fn main() -> Result<()> {
                                         recipe,
                                         name,
                                         key,
+                                        entrypoint,
+                                        entrypoint_config,
                                         force,
-                                    } => publish_recipe(&client, &load_project(project), name, key, recipe, force).await,
+                                    } => publish_recipe(&client, &load_project(project), name, key, recipe, entrypoint, entrypoint_config, force).await,
                     Commands::Run { project, args } => {
                                         run_recipe(&client, &load_project(project), args).await
                                     }
@@ -545,24 +553,20 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
 }
 
 fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P) -> Result<TempPath> {
-    if recipe_dir.as_ref().join("main.py").is_file() {
-        let tmp_file = NamedTempFile::new()?;
+    let tmp_file = NamedTempFile::new()?;
 
-        {
-            let mut zip_file = ZipWriter::new(&tmp_file);
-            let options =
-                SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-            zip_file.create_from_directory_with_options(
-                &recipe_dir.as_ref().to_owned(),
-                |_| options,
-                &ZipIgnoreEntryHandler::new(),
-            )?;
-        }
-
-        Ok(tmp_file.into_temp_path())
-    } else {
-        bail!("Recipe directory must contain a main.py file");
+    {
+        let mut zip_file = ZipWriter::new(&tmp_file);
+        let options =
+            SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        zip_file.create_from_directory_with_options(
+            &recipe_dir.as_ref().to_owned(),
+            |_| options,
+            &ZipIgnoreEntryHandler::new(),
+        )?;
     }
+
+    Ok(tmp_file.into_temp_path())
 }
 
 async fn publish_recipe<P: AsRef<Path>>(
@@ -571,6 +575,8 @@ async fn publish_recipe<P: AsRef<Path>>(
     name: Option<String>,
     key: Option<String>,
     recipe: P,
+    entrypoint: Option<String>,
+    entrypoint_config: Option<String>,
     force: bool,
 ) -> Result<()> {
     let name = name.unwrap_or_else(|| {
@@ -607,6 +613,8 @@ async fn publish_recipe<P: AsRef<Path>>(
                 None,
                 None,
                 Some(recipe_path.as_ref()),
+                entrypoint,
+                entrypoint_config,
             )
             .await?;
 
@@ -614,9 +622,13 @@ async fn publish_recipe<P: AsRef<Path>>(
     } else {
         let response = if recipe.as_ref().is_dir() {
             let recipe = zip_recipe_dir(recipe)?;
-            client.publish_recipe(project, &name, &key, &recipe).await?
+            client
+                .publish_recipe(project, &name, &key, &recipe, entrypoint, entrypoint_config)
+                .await?
         } else {
-            client.publish_recipe(project, &name, &key, recipe).await?
+            client
+                .publish_recipe(project, &name, &key, recipe, entrypoint, entrypoint_config)
+                .await?
         };
         (response.id, response.key)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,10 +231,10 @@ enum Commands {
         #[arg(short, long)]
         key: Option<String>,
         /// Custom entrypoint file (relative path within directory)
-        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        #[arg(short, long, value_hint = ValueHint::FilePath, value_parser = validate_entrypoint)]
         entrypoint: Option<String>,
         /// Custom config entrypoint file (relative path within directory)
-        #[arg(short = 'c', long, value_hint = ValueHint::FilePath)]
+        #[arg(short = 'c', long, value_hint = ValueHint::FilePath, value_parser = validate_entrypoint)]
         entrypoint_config: Option<String>,
         /// Update existing recipe if it exists
         #[arg(short, long)]
@@ -550,6 +550,20 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     element!(RecipeList(recipes: recipes)).print();
 
     Ok(())
+}
+
+fn validate_entrypoint(s: &str) -> Result<String, String> {
+    let path = Path::new(s);
+    if path.is_absolute() {
+        return Err("entrypoint must be a relative path".into());
+    }
+    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        return Err("entrypoint must not contain '..' components".into());
+    }
+    if path.extension().and_then(|e| e.to_str()) != Some("py") {
+        return Err("entrypoint must be a Python file (.py)".into());
+    }
+    Ok(s.to_string())
 }
 
 fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, entrypoint_config: &Option<String>) -> Result<TempPath> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use std::{
     time::SystemTime,
 };
 use tempfile::{NamedTempFile, TempPath};
+use typed_path::Utf8TypedPath;
 use tokio::{runtime::Handle, sync::watch};
 use url::Url;
 use uuid::Uuid;
@@ -230,11 +231,11 @@ enum Commands {
         /// Recipe key
         #[arg(short, long)]
         key: Option<String>,
-        /// Custom entrypoint file (relative path within directory)
-        #[arg(short, long, value_hint = ValueHint::FilePath, value_parser = validate_entrypoint)]
+        /// Custom entrypoint file
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
         entrypoint: Option<String>,
-        /// Custom config entrypoint file (relative path within directory)
-        #[arg(short = 'c', long, value_hint = ValueHint::FilePath, value_parser = validate_entrypoint)]
+        /// Custom config entrypoint file
+        #[arg(short = 'c', long, value_hint = ValueHint::FilePath)]
         entrypoint_config: Option<String>,
         /// Update existing recipe if it exists
         #[arg(short, long)]
@@ -552,19 +553,6 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_entrypoint(s: &str) -> Result<String, String> {
-    let path = Path::new(s);
-    if path.is_absolute() {
-        return Err("entrypoint must be a relative path".into());
-    }
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
-        return Err("entrypoint must not contain '..' components".into());
-    }
-    if path.extension().and_then(|e| e.to_str()) != Some("py") {
-        return Err("entrypoint must be a Python file (.py)".into());
-    }
-    Ok(s.to_string())
-}
 
 fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, entrypoint_config: &Option<String>) -> Result<TempPath> {
     if let Some(ep) = entrypoint {
@@ -597,6 +585,29 @@ fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, en
     Ok(tmp_file.into_temp_path())
 }
 
+fn resolve_entrypoint(recipe_dir: &Path, entrypoint: Option<String>) -> Result<Option<String>> {
+    let Some(ep) = entrypoint else {
+        return Ok(None);
+    };
+
+    let ep_path = Path::new(&ep);
+    if ep_path.extension().and_then(|e| e.to_str()) != Some("py") {
+        bail!("entrypoint must be a Python file (.py)");
+    }
+
+    let relative = ep_path
+        .strip_prefix(recipe_dir)
+        .unwrap_or(ep_path);
+
+    let resolved = recipe_dir.join(relative);
+    if !resolved.starts_with(recipe_dir) {
+        bail!("entrypoint must be contained within the recipe directory");
+    }
+
+    let unix = Utf8TypedPath::derive(&relative.to_string_lossy()).with_unix_encoding();
+    Ok(Some(unix.to_string()))
+}
+
 async fn publish_recipe<P: AsRef<Path>>(
     client: &AdaptiveClient,
     project: &str,
@@ -607,6 +618,9 @@ async fn publish_recipe<P: AsRef<Path>>(
     entrypoint_config: Option<String>,
     force: bool,
 ) -> Result<()> {
+    let entrypoint = resolve_entrypoint(recipe.as_ref(), entrypoint)?;
+    let entrypoint_config = resolve_entrypoint(recipe.as_ref(), entrypoint_config)?;
+
     let name = name.unwrap_or_else(|| {
         recipe
             .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -552,7 +552,11 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     Ok(())
 }
 
-fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P) -> Result<TempPath> {
+fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>) -> Result<TempPath> {
+    if entrypoint.is_none() && !recipe_dir.as_ref().join("main.py").is_file() {
+        bail!("Recipe directory must contain a main.py file, or specify --entrypoint");
+    }
+
     let tmp_file = NamedTempFile::new()?;
 
     {
@@ -600,7 +604,7 @@ async fn publish_recipe<P: AsRef<Path>>(
         }
 
         let recipe_path: Box<dyn AsRef<Path> + Send> = if recipe.as_ref().is_dir() {
-            Box::new(zip_recipe_dir(&recipe)?)
+            Box::new(zip_recipe_dir(&recipe, &entrypoint)?)
         } else {
             Box::new(recipe.as_ref().to_path_buf())
         };
@@ -621,7 +625,7 @@ async fn publish_recipe<P: AsRef<Path>>(
         (response.id, response.key)
     } else {
         let response = if recipe.as_ref().is_dir() {
-            let recipe = zip_recipe_dir(recipe)?;
+            let recipe = zip_recipe_dir(recipe, &entrypoint)?;
             client
                 .publish_recipe(project, &name, &key, &recipe, entrypoint, entrypoint_config)
                 .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -575,10 +575,10 @@ fn zip_recipe_dir<P: AsRef<Path>>(
         bail!("Recipe directory must contain a main.py file, or specify --entrypoint");
     }
 
-    if let Some(ep) = entrypoint_config {
-        if !recipe_dir.as_ref().join(ep).is_file() {
-            bail!("Config entrypoint file '{ep}' does not exist in recipe directory");
-        }
+    if let Some(ep) = entrypoint_config
+        && !recipe_dir.as_ref().join(ep).is_file()
+    {
+        bail!("Config entrypoint file '{ep}' does not exist in recipe directory");
     }
 
     let tmp_file = NamedTempFile::new()?;
@@ -617,6 +617,7 @@ fn resolve_entrypoint(recipe_dir: &Path, entrypoint: Option<String>) -> Result<O
     Ok(Some(unix.to_string()))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn publish_recipe<P: AsRef<Path>>(
     client: &AdaptiveClient,
     project: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,8 @@ use std::{
     time::SystemTime,
 };
 use tempfile::{NamedTempFile, TempPath};
-use typed_path::Utf8TypedPath;
 use tokio::{runtime::Handle, sync::watch};
+use typed_path::Utf8TypedPath;
 use url::Url;
 use uuid::Uuid;
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
@@ -562,8 +562,11 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     Ok(())
 }
 
-
-fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, entrypoint_config: &Option<String>) -> Result<TempPath> {
+fn zip_recipe_dir<P: AsRef<Path>>(
+    recipe_dir: P,
+    entrypoint: &Option<String>,
+    entrypoint_config: &Option<String>,
+) -> Result<TempPath> {
     if let Some(ep) = entrypoint {
         if !recipe_dir.as_ref().join(ep).is_file() {
             bail!("Entrypoint file '{ep}' does not exist in recipe directory");
@@ -582,8 +585,7 @@ fn zip_recipe_dir<P: AsRef<Path>>(recipe_dir: P, entrypoint: &Option<String>, en
 
     {
         let mut zip_file = ZipWriter::new(&tmp_file);
-        let options =
-            SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
         zip_file.create_from_directory_with_options(
             &recipe_dir.as_ref().to_owned(),
             |_| options,
@@ -604,9 +606,7 @@ fn resolve_entrypoint(recipe_dir: &Path, entrypoint: Option<String>) -> Result<O
         bail!("entrypoint must be a Python file (.py)");
     }
 
-    let relative = ep_path
-        .strip_prefix(recipe_dir)
-        .unwrap_or(ep_path);
+    let relative = ep_path.strip_prefix(recipe_dir).unwrap_or(ep_path);
 
     let resolved = recipe_dir.join(relative);
     if !resolved.starts_with(recipe_dir) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,15 @@ impl Commands {
     }
 }
 
+fn build_adaptive_client(base_url: Url, api_key: String) -> AdaptiveClient {
+    let inner = reqwest::Client::builder()
+        .user_agent(concat!("adpt/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("Failed to build HTTP client");
+    let http_client = reqwest_middleware::ClientBuilder::new(inner).build();
+    AdaptiveClient::new(http_client, base_url, api_key, None)
+}
+
 fn main() -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -320,7 +329,7 @@ fn main() -> Result<()> {
             Commands::SetApiKey { api_key } => config::set_api_key_keyring(api_key),
             requires_api_key => {
                 let config = config::read_config()?;
-                let client = AdaptiveClient::new(config.adaptive_base_url, config.adaptive_api_key);
+                let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
                 let default_project = config.default_project.clone();
 
                 let load_project = |maybe_project: Option<String>| {
@@ -696,7 +705,7 @@ fn recipe_key_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
 
     let config = config::read_config().expect("Failed to read config");
 
-    let client = AdaptiveClient::new(config.adaptive_base_url, config.adaptive_api_key);
+    let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
     let recipes = handle
@@ -722,7 +731,7 @@ fn project_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
 
     let config = config::read_config().expect("Failed to read config");
 
-    let client = AdaptiveClient::new(config.adaptive_base_url, config.adaptive_api_key);
+    let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
     let projects = handle.block_on(client.list_projects()).unwrap();
@@ -744,7 +753,7 @@ fn pool_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
 
     let config = config::read_config().expect("Failed to read config");
 
-    let client = AdaptiveClient::new(config.adaptive_base_url, config.adaptive_api_key);
+    let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
     let pools = handle.block_on(client.list_pools()).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -279,7 +279,8 @@ impl ModelDisplay for ListModelsProjectModelServices {
             list_models::ModelServiceStatus::OFFLINE => "Offline".to_string(),
             list_models::ModelServiceStatus::TURNED_OFF => "Turned Off".to_string(),
             list_models::ModelServiceStatus::ERROR => "Error".to_string(),
-            list_models::ModelServiceStatus::UNHEALTHY => "Unhealthy".to_string(),
+            list_models::ModelServiceStatus::DEGRADED => "Degraded".to_string(),
+            list_models::ModelServiceStatus::SCALING => "Scaling".to_string(),
             list_models::ModelServiceStatus::Other(ref other) => other.to_owned(),
         }
     }
@@ -309,7 +310,8 @@ impl ModelDisplay for ListAllModelsModels {
                 list_all_models::ModelOnline::OFFLINE => "Offline".to_string(),
                 list_all_models::ModelOnline::PENDING => "Pending".to_string(),
                 list_all_models::ModelOnline::ERROR => "Error".to_string(),
-                list_all_models::ModelOnline::UNHEALTHY => "Unhealthy".to_string(),
+                list_all_models::ModelOnline::DEGRADED => "Degraded".to_string(),
+                list_all_models::ModelOnline::SCALING => "Scaling".to_string(),
                 list_all_models::ModelOnline::Other(other) => other.to_owned(),
             }
         }


### PR DESCRIPTION
- Add `--entrypoint` (`-e`) and `--entrypoint-config` (`-c`) flags to adpt publish for custom recipe entrypoints
- Remove `main.py` requirement for directory recipes when a custom entrypoint is specified
- Add file path autocomplete for both new flags

Requiring https://github.com/adaptive-ml/adaptive/pull/4152