### PR TITLE
🎨 Drop grey row stripe for dark-mode table readability

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -141,9 +141,9 @@ pub fn render_list(config: ListConfig, rows: Vec<Vec<Cell>>) -> impl Into<AnyEle
                     })
                     .collect();
 
+                let _ = i;
                 element! {
                     View(
-                        background_color: if i % 2 == 0 { None } else { Some(Color::Grey) },
                         gap: 2u32,
                     ) {
                         #(cells)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -101,8 +101,7 @@ pub fn render_list(config: ListConfig, rows: Vec<Vec<Cell>>) -> impl Into<AnyEle
         ]
     } else {
         rows.into_iter()
-            .enumerate()
-            .map(|(i, row)| {
+            .map(|row| {
                 let cells: Vec<AnyElement<'static>> = row
                     .into_iter()
                     .enumerate()
@@ -141,7 +140,6 @@ pub fn render_list(config: ListConfig, rows: Vec<Vec<Cell>>) -> impl Into<AnyEle
                     })
                     .collect();
 
-                let _ = i;
                 element! {
                     View(
                         gap: 2u32,


### PR DESCRIPTION
## Summary
- Drops the alternating `Color::Grey` row background from `render_list` in `src/ui.rs`. On dark terminals the grey-on-default stripe is hard to read; on light terminals it's just visual noise.
- Header is already bold + underlined and `gap: 2` keeps rows distinguishable, so no replacement is needed.

Closes FE-13.