### PR TITLE
✨ Add adpt project subcommands (set, list)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,7 @@ version = 4
 
 [[package]]
 name = "adaptive-client-rust"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6020eba2a7cd5a4fc79092df363d7c793d7b4aee8bf637c4f043a3916aa450"
+version = "0.14.2"
 dependencies = [
  "async-stream",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A tool for interacting with the Adaptive platform"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-adaptive-client-rust = "0.14.1"
+adaptive-client-rust = "0.14.2"
 anyhow = "1.0.100"
 async-stream = "0.3"
 futures = "0.3"

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -34,6 +34,7 @@ This document contains the help content for the `adpt` command-line program.
 * [`adpt team list`↴](#adpt-team-list)
 * [`adpt project`↴](#adpt-project)
 * [`adpt project set`↴](#adpt-project-set)
+* [`adpt project list`↴](#adpt-project-list)
 
 ## `adpt`
 
@@ -440,6 +441,7 @@ Manage the default project
 ###### **Subcommands:**
 
 * `set` — Set the default project used when --project is not specified
+* `list` — List all projects
 
 
 
@@ -452,6 +454,14 @@ Set the default project used when --project is not specified
 ###### **Arguments:**
 
 * `<PROJECT>`
+
+
+
+## `adpt project list`
+
+List all projects
+
+**Usage:** `adpt project list`
 
 
 

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -32,6 +32,8 @@ This document contains the help content for the `adpt` command-line program.
 * [`adpt team add-member`↴](#adpt-team-add-member)
 * [`adpt team remove-member`↴](#adpt-team-remove-member)
 * [`adpt team list`↴](#adpt-team-list)
+* [`adpt project`↴](#adpt-project)
+* [`adpt project set`↴](#adpt-project-set)
 
 ## `adpt`
 
@@ -55,6 +57,7 @@ A tool interacting with the Adaptive platform
 * `role` — Manage roles
 * `user` — Manage users
 * `team` — Manage teams
+* `project` — Manage the default project
 
 
 
@@ -425,6 +428,30 @@ Remove a user from a team
 List all teams
 
 **Usage:** `adpt team list`
+
+
+
+## `adpt project`
+
+Manage the default project
+
+**Usage:** `adpt project <COMMAND>`
+
+###### **Subcommands:**
+
+* `set` — Set the default project used when --project is not specified
+
+
+
+## `adpt project set`
+
+Set the default project used when --project is not specified
+
+**Usage:** `adpt project set <PROJECT>`
+
+###### **Arguments:**
+
+* `<PROJECT>`
 
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,15 @@ fn get_config_file_path() -> Result<PathBuf> {
     }
 }
 
+pub fn read_config_file() -> Result<ConfigFile> {
+    let config_file = get_config_file_path()?;
+    if let Ok(contents) = fs::read_to_string(config_file) {
+        Ok(toml::from_str(&contents)?)
+    } else {
+        Ok(ConfigFile::default())
+    }
+}
+
 pub fn read_config() -> Result<Config> {
     let _ = dotenv();
     let env_config = envy::from_env::<ConfigEnv>().unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,20 @@ enum Commands {
         #[command(subcommand)]
         command: TeamCommands,
     },
+    /// Manage the default project
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum ProjectCommands {
+    /// Set the default project used when --project is not specified
+    Set {
+        #[arg(add = ArgValueCompleter::new(project_completer))]
+        project: String,
+    },
 }
 
 impl Commands {
@@ -296,6 +310,7 @@ impl Commands {
             Commands::Role { .. } => "role",
             Commands::User { .. } => "user",
             Commands::Team { .. } => "team",
+            Commands::Project { .. } => "project",
         }
     }
 }
@@ -327,6 +342,11 @@ fn main() -> Result<()> {
         match cli.command {
             Commands::Config => interactive_config(),
             Commands::SetApiKey { api_key } => config::set_api_key_keyring(api_key),
+            Commands::Project { command: ProjectCommands::Set { project } } => {
+                let mut file_config = config::read_config_file()?;
+                file_config.default_project = Some(project);
+                config::write_config(file_config)
+            }
             requires_api_key => {
                 let config = config::read_config()?;
                 let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
@@ -412,6 +432,7 @@ fn main() -> Result<()> {
                         }
                         TeamCommands::List => list_teams(&client).await,
                     },
+                    Commands::Project { .. } => unreachable!("handled above"),
                 }
             },
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -983,16 +983,20 @@ async fn list_projects_cmd(client: &AdaptiveClient) -> Result<()> {
         let config = ListConfig {
             columns: vec![
                 Column {
-                    header: "Id",
-                    width: Some(36),
-                },
-                Column {
                     header: "Key",
                     width: Some(25),
                 },
                 Column {
                     header: "Name",
-                    width: None,
+                    width: Some(30),
+                },
+                Column {
+                    header: "Owner team",
+                    width: Some(25),
+                },
+                Column {
+                    header: "Created",
+                    width: Some(12),
                 },
             ],
             empty_message: "No projects found",
@@ -1000,10 +1004,23 @@ async fn list_projects_cmd(client: &AdaptiveClient) -> Result<()> {
         let rows: Vec<Vec<Cell>> = projects
             .iter()
             .map(|p| {
+                let owner_team = p
+                    .shares
+                    .iter()
+                    .find(|s| s.is_owner)
+                    .and_then(|s| s.team.as_ref())
+                    .map(|t| t.name.clone())
+                    .unwrap_or_default();
+                let created = humantime::format_rfc3339(p.created_at.0)
+                    .to_string()
+                    .get(..10)
+                    .unwrap_or("")
+                    .to_string();
                 vec![
-                    Cell::from(p.id.to_string()),
                     Cell::from(p.key.as_str()),
                     Cell::from(p.name.as_str()),
+                    Cell::from(owner_team),
+                    Cell::from(created),
                 ]
             })
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,8 @@ enum ProjectCommands {
         #[arg(add = ArgValueCompleter::new(project_completer))]
         project: String,
     },
+    /// List all projects
+    List,
 }
 
 impl Commands {
@@ -432,7 +434,10 @@ fn main() -> Result<()> {
                         }
                         TeamCommands::List => list_teams(&client).await,
                     },
-                    Commands::Project { .. } => unreachable!("handled above"),
+                    Commands::Project { command } => match command {
+                        ProjectCommands::Set { .. } => unreachable!("handled above"),
+                        ProjectCommands::List => list_projects_cmd(&client).await,
+                    },
                 }
             },
         }
@@ -966,6 +971,48 @@ async fn remove_team_member(client: &AdaptiveClient, user: &str, team: &str) -> 
         );
     } else {
         println!("{}", response.id);
+    }
+
+    Ok(())
+}
+
+async fn list_projects_cmd(client: &AdaptiveClient) -> Result<()> {
+    let projects = client.list_projects().await?;
+
+    if io::stdout().is_terminal() {
+        let config = ListConfig {
+            columns: vec![
+                Column {
+                    header: "Id",
+                    width: Some(36),
+                },
+                Column {
+                    header: "Key",
+                    width: Some(25),
+                },
+                Column {
+                    header: "Name",
+                    width: None,
+                },
+            ],
+            empty_message: "No projects found",
+        };
+        let rows: Vec<Vec<Cell>> = projects
+            .iter()
+            .map(|p| {
+                vec![
+                    Cell::from(p.id.to_string()),
+                    Cell::from(p.key.as_str()),
+                    Cell::from(p.name.as_str()),
+                ]
+            })
+            .collect();
+        let mut el: AnyElement<'static> = render_list(config, rows).into();
+        el.print();
+    } else {
+        for p in &projects {
+            println!("{}", p.key);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- New `adpt project set <project>` writes `default_project` to the user's config (`~/.adpt/config.toml` on macOS, XDG dir elsewhere). Reuses existing `project_completer` for the arg.
- New `adpt project list` prints all projects — table (Id/Key/Name) on a TTY, plain keys one-per-line when piped.
- `project set` doesn't require an API key (writes only); `project list` does.
- `CommandLineHelp.md` regenerated.

Closes FE-14.