### PR TITLE
Show recipe IDs in adpt recipes list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,7 @@ version = 4
 
 [[package]]
 name = "adaptive-client-rust"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6020eba2a7cd5a4fc79092df363d7c793d7b4aee8bf637c4f043a3916aa450"
+version = "0.14.2"
 dependencies = [
  "async-stream",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A tool for interacting with the Adaptive platform"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-adaptive-client-rust = "0.14.1"
+adaptive-client-rust = "0.14.2"
 anyhow = "1.0.100"
 async-stream = "0.3"
 futures = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,7 +557,13 @@ async fn get_job(client: Arc<AdaptiveClient>, job_id: Uuid, follow: bool) -> Res
 async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     let recipes = client.list_recipes(project).await?;
 
-    element!(RecipeList(recipes: recipes)).print();
+    if io::stdout().is_terminal() {
+        element!(RecipeList(recipes: recipes)).print();
+    } else {
+        for recipe in &recipes {
+            println!("{}", recipe.id);
+        }
+    }
 
     Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -216,16 +216,27 @@ pub struct RecipeListProps {
 #[component]
 pub fn RecipeList(props: &RecipeListProps) -> impl Into<AnyElement<'static>> {
     let config = ListConfig {
-        columns: vec![Column {
-            header: "Name",
-            width: None,
-        }],
+        columns: vec![
+            Column {
+                header: "Id",
+                width: Some(36),
+            },
+            Column {
+                header: "Name",
+                width: None,
+            },
+        ],
         empty_message: "No recipes found",
     };
     let rows: Vec<Vec<Cell>> = props
         .recipes
         .iter()
-        .map(|recipe| vec![Cell::from(recipe.name.as_str())])
+        .map(|recipe| {
+            vec![
+                Cell::from(recipe.id.to_string()),
+                Cell::from(recipe.name.as_str()),
+            ]
+        })
         .collect();
     render_list(config, rows)
 }


### PR DESCRIPTION
## Summary
- `adpt recipes list` now includes recipe IDs (an `Id` column on the TTY table, and one ID per line in pipe mode so the output composes with `xargs` / `jq`).
- Depends on `adaptive-client-rust` 0.14.2 (PR adaptive-ml/adaptive#4762) which adds `id` to the `customRecipes` selection.

Closes FE-12