### PR TITLE
Add 'adpt models add' + restructure into models subcommands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check CLI help markdown is up-to-date
         run: |
-          cargo run -- --markdown-help models > CommandLineHelp.md.new
+          cargo run -- --markdown-help jobs > CommandLineHelp.md.new
           if ! difft --exit-code --display side-by-side-show-both CommandLineHelp.md CommandLineHelp.md.new; then
             echo "::error::CommandLineHelp.md is out of date. Run 'cargo run -- --markdown-help > CommandLineHelp.md' and commit the result."
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,7 @@ version = 4
 
 [[package]]
 name = "adaptive-client-rust"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6020eba2a7cd5a4fc79092df363d7c793d7b4aee8bf637c4f043a3916aa450"
+version = "0.14.2"
 dependencies = [
  "async-stream",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A tool for interacting with the Adaptive platform"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-adaptive-client-rust = "0.14.1"
+adaptive-client-rust = "0.14.2"
 anyhow = "1.0.100"
 async-stream = "0.3"
 futures = "0.3"

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -10,6 +10,8 @@ This document contains the help content for the `adpt` command-line program.
 * [`adpt job`↴](#adpt-job)
 * [`adpt jobs`↴](#adpt-jobs)
 * [`adpt models`↴](#adpt-models)
+* [`adpt models list`↴](#adpt-models-list)
+* [`adpt models add`↴](#adpt-models-add)
 * [`adpt upload`↴](#adpt-upload)
 * [`adpt publish`↴](#adpt-publish)
 * [`adpt recipes`↴](#adpt-recipes)
@@ -45,7 +47,7 @@ A tool interacting with the Adaptive platform
 * `config` — Configure adpt interactively
 * `job` — Inspect job
 * `jobs` — List currently running jobs
-* `models` — List models
+* `models` — Manage models
 * `upload` — Upload dataset
 * `publish` — Upload recipe
 * `recipes` — List recipes
@@ -104,14 +106,43 @@ List currently running jobs
 
 ## `adpt models`
 
+Manage models
+
+**Usage:** `adpt models <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List models
+* `add` — Add models from the organization to a project
+
+
+
+## `adpt models list`
+
 List models
 
-**Usage:** `adpt models [OPTIONS]`
+**Usage:** `adpt models list [OPTIONS]`
 
 ###### **Options:**
 
 * `-p`, `--project <PROJECT>`
 * `-a`, `--all` — List all models in the global model registry
+
+
+
+## `adpt models add`
+
+Add models from the organization to a project
+
+**Usage:** `adpt models add [OPTIONS] [MODELS]...`
+
+###### **Arguments:**
+
+* `<MODELS>` — One or more model IDs or keys to add to the project
+
+###### **Options:**
+
+* `-p`, `--project <PROJECT>`
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,26 @@ enum TeamCommands {
 }
 
 #[derive(Subcommand)]
+enum ModelsCommands {
+    /// List models
+    List {
+        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
+        project: Option<String>,
+        /// List all models in the global model registry
+        #[arg(short, long)]
+        all: bool,
+    },
+    /// Add models from the organization to a project
+    Add {
+        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
+        project: Option<String>,
+        /// One or more model IDs or keys to add to the project
+        #[arg(add = ArgValueCompleter::new(model_completer))]
+        models: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum Commands {
     /// Cancel a job
     Cancel { id: Uuid },
@@ -201,13 +221,10 @@ enum Commands {
     },
     /// List currently running jobs
     Jobs,
-    /// List models
+    /// Manage models
     Models {
-        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
-        project: Option<String>,
-        /// List all models in the global model registry
-        #[arg(short, long)]
-        all: bool,
+        #[command(subcommand)]
+        command: ModelsCommands,
     },
     /// Upload dataset
     Upload {
@@ -357,16 +374,26 @@ fn main() -> Result<()> {
                                     }
                     Commands::Jobs => list_jobs(&client, None).await,
                     Commands::Cancel { id } => cancel_job(&client, id).await,
-                    Commands::Models { project, all } => {
-                                        if all {
-                                            list_all_models(&client).await
-                                        } else {
-                                            match project.or(config.default_project) {
-                                                Some(project) => list_models(&client, project).await,
-                                                None => list_all_models(&client).await,
-                                            }
-                                        }
-                                    }
+                    Commands::Models { command } => match command {
+                        ModelsCommands::List { project, all } => {
+                            if all {
+                                list_all_models(&client).await
+                            } else {
+                                match project.or(config.default_project) {
+                                    Some(project) => list_models(&client, project).await,
+                                    None => list_all_models(&client).await,
+                                }
+                            }
+                        }
+                        ModelsCommands::Add { project, models } => {
+                            add_models_to_project_cmd(
+                                &client,
+                                &load_project(project),
+                                models,
+                            )
+                            .await
+                        }
+                    },
                     Commands::Schema { project, recipe } => {
                                         print_schema(&client, load_project(project), recipe).await
                                     }
@@ -523,6 +550,30 @@ async fn print_schema(client: &AdaptiveClient, project: String, recipe: String) 
 async fn list_models(client: &AdaptiveClient, project: String) -> Result<()> {
     let model_services = client.list_models(project).await?;
     element!(ModelsList(model_services: model_services)).print();
+    Ok(())
+}
+
+async fn add_models_to_project_cmd(
+    client: &AdaptiveClient,
+    project: &str,
+    models: Vec<String>,
+) -> Result<()> {
+    if models.is_empty() {
+        return Err(anyhow::anyhow!("At least one model must be specified"));
+    }
+    let result = client.add_models_to_project(project, models).await?;
+
+    if result.success {
+        println!("Models added to project {}", project);
+    } else {
+        for failure in &result.failures {
+            eprintln!("Failed to add {}: {}", failure.model, failure.reason);
+        }
+        return Err(anyhow::anyhow!(
+            "{} model(s) failed to add",
+            result.failures.len()
+        ));
+    }
     Ok(())
 }
 
@@ -740,6 +791,28 @@ fn project_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
     projects.into_iter().for_each(|project| {
         if project.key.starts_with(current) {
             completions.push(CompletionCandidate::new(project.key));
+        }
+    });
+
+    completions
+}
+
+fn model_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let Some(current) = current.to_str() else {
+        return completions;
+    };
+
+    let config = config::read_config().expect("Failed to read config");
+
+    let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
+
+    let handle = Handle::current();
+    let models = handle.block_on(client.list_all_models()).unwrap();
+
+    models.into_iter().for_each(|model| {
+        if model.key.starts_with(current) {
+            completions.push(CompletionCandidate::new(model.key));
         }
     });
 


### PR DESCRIPTION
## Summary
- Refactors `adpt models` into a subcommand group: `adpt models list` (preserves existing behavior, supports `-p` / `-a`) and `adpt models add -p <project> <model>...` to bind models to a project.
- Adds a `model_completer` so the model argument autocompletes against org models.
- Depends on `adaptive-client-rust` 0.14.2 (PR adaptive-ml/adaptive#4762) which adds the `addModelsToProject` mutation wrapper.

Closes FE-17