### PR TITLE
Add 'adpt recipes delete', group publish/list/delete under recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,7 @@ version = 4
 
 [[package]]
 name = "adaptive-client-rust"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6020eba2a7cd5a4fc79092df363d7c793d7b4aee8bf637c4f043a3916aa450"
+version = "0.14.2"
 dependencies = [
  "async-stream",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A tool for interacting with the Adaptive platform"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-adaptive-client-rust = "0.14.1"
+adaptive-client-rust = "0.14.2"
 anyhow = "1.0.100"
 async-stream = "0.3"
 futures = "0.3"

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -11,8 +11,10 @@ This document contains the help content for the `adpt` command-line program.
 * [`adpt jobs`↴](#adpt-jobs)
 * [`adpt models`↴](#adpt-models)
 * [`adpt upload`↴](#adpt-upload)
-* [`adpt publish`↴](#adpt-publish)
 * [`adpt recipes`↴](#adpt-recipes)
+* [`adpt recipes list`↴](#adpt-recipes-list)
+* [`adpt recipes delete`↴](#adpt-recipes-delete)
+* [`adpt recipes publish`↴](#adpt-recipes-publish)
 * [`adpt run`↴](#adpt-run)
 * [`adpt schema`↴](#adpt-schema)
 * [`adpt set-api-key`↴](#adpt-set-api-key)
@@ -47,8 +49,7 @@ A tool interacting with the Adaptive platform
 * `jobs` — List currently running jobs
 * `models` — List models
 * `upload` — Upload dataset
-* `publish` — Upload recipe
-* `recipes` — List recipes
+* `recipes` — Manage recipes
 * `run` — Run recipe
 * `schema` — Display the schema for inputs for a recipe
 * `set-api-key` — Store your API key in the OS keyring
@@ -132,11 +133,53 @@ Upload dataset
 
 
 
-## `adpt publish`
+## `adpt recipes`
+
+Manage recipes
+
+**Usage:** `adpt recipes <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List recipes
+* `delete` — Delete a recipe
+* `publish` — Upload recipe
+
+
+
+## `adpt recipes list`
+
+List recipes
+
+**Usage:** `adpt recipes list [OPTIONS]`
+
+###### **Options:**
+
+* `-p`, `--project <PROJECT>`
+
+
+
+## `adpt recipes delete`
+
+Delete a recipe
+
+**Usage:** `adpt recipes delete [OPTIONS] <RECIPE>`
+
+###### **Arguments:**
+
+* `<RECIPE>` — Recipe ID or key
+
+###### **Options:**
+
+* `-p`, `--project <PROJECT>`
+
+
+
+## `adpt recipes publish`
 
 Upload recipe
 
-**Usage:** `adpt publish [OPTIONS] <RECIPE>`
+**Usage:** `adpt recipes publish [OPTIONS] <RECIPE>`
 
 ###### **Arguments:**
 
@@ -150,18 +193,6 @@ Upload recipe
 * `-e`, `--entrypoint <ENTRYPOINT>` — Custom entrypoint file
 * `-c`, `--entrypoint-config <ENTRYPOINT_CONFIG>` — Custom config entrypoint file
 * `-f`, `--force` — Update existing recipe if it exists
-
-
-
-## `adpt recipes`
-
-List recipes
-
-**Usage:** `adpt recipes [OPTIONS]`
-
-###### **Options:**
-
-* `-p`, `--project <PROJECT>`
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,45 @@ enum TeamCommands {
 }
 
 #[derive(Subcommand)]
+enum RecipesCommands {
+    /// List recipes
+    List {
+        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
+        project: Option<String>,
+    },
+    /// Delete a recipe
+    Delete {
+        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
+        project: Option<String>,
+        /// Recipe ID or key
+        #[arg(add = ArgValueCompleter::new(recipe_key_completer))]
+        recipe: String,
+    },
+    /// Upload recipe
+    Publish {
+        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
+        project: Option<String>,
+        #[arg(value_hint = ValueHint::AnyPath)]
+        recipe: PathBuf,
+        /// Recipe name
+        #[arg(short, long)]
+        name: Option<String>,
+        /// Recipe key
+        #[arg(short, long)]
+        key: Option<String>,
+        /// Custom entrypoint file
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        entrypoint: Option<String>,
+        /// Custom config entrypoint file
+        #[arg(short = 'c', long, value_hint = ValueHint::FilePath)]
+        entrypoint_config: Option<String>,
+        /// Update existing recipe if it exists
+        #[arg(short, long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum Commands {
     /// Cancel a job
     Cancel { id: Uuid },
@@ -219,32 +258,10 @@ enum Commands {
         #[arg(short, long)]
         name: Option<String>,
     },
-    /// Upload recipe
-    Publish {
-        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
-        project: Option<String>,
-        #[arg(value_hint = ValueHint::AnyPath)]
-        recipe: PathBuf,
-        /// Recipe name
-        #[arg(short, long)]
-        name: Option<String>,
-        /// Recipe key
-        #[arg(short, long)]
-        key: Option<String>,
-        /// Custom entrypoint file
-        #[arg(short, long, value_hint = ValueHint::FilePath)]
-        entrypoint: Option<String>,
-        /// Custom config entrypoint file
-        #[arg(short = 'c', long, value_hint = ValueHint::FilePath)]
-        entrypoint_config: Option<String>,
-        /// Update existing recipe if it exists
-        #[arg(short, long)]
-        force: bool,
-    },
-    /// List recipes
+    /// Manage recipes
     Recipes {
-        #[arg(short, long, add = ArgValueCompleter::new(project_completer))]
-        project: Option<String>,
+        #[command(subcommand)]
+        command: RecipesCommands,
     },
     /// Run recipe
     Run {
@@ -288,7 +305,6 @@ impl Commands {
             Commands::Jobs => "jobs",
             Commands::Models { .. } => "models",
             Commands::Upload { .. } => "upload",
-            Commands::Publish { .. } => "publish",
             Commands::Recipes { .. } => "recipes",
             Commands::Run { .. } => "run",
             Commands::Schema { .. } => "schema",
@@ -339,19 +355,24 @@ fn main() -> Result<()> {
                 };
 
                 match requires_api_key {
-                    Commands::Recipes { project } => {
-                                        list_recipes(&client, &load_project(project)).await
-                                    }
+                    Commands::Recipes { command } => match command {
+                        RecipesCommands::List { project } => {
+                            list_recipes(&client, &load_project(project)).await
+                        }
+                        RecipesCommands::Delete { project, recipe } => {
+                            delete_recipe(&client, &load_project(project), &recipe).await
+                        }
+                        RecipesCommands::Publish {
+                            project,
+                            recipe,
+                            name,
+                            key,
+                            entrypoint,
+                            entrypoint_config,
+                            force,
+                        } => publish_recipe(&client, &load_project(project), name, key, recipe, entrypoint, entrypoint_config, force).await,
+                    },
                     Commands::Job { id, follow } => get_job(Arc::new(client), id, follow).await,
-                    Commands::Publish {
-                                        project,
-                                        recipe,
-                                        name,
-                                        key,
-                                        entrypoint,
-                                        entrypoint_config,
-                                        force,
-                                    } => publish_recipe(&client, &load_project(project), name, key, recipe, entrypoint, entrypoint_config, force).await,
                     Commands::Run { project, args } => {
                                         run_recipe(&client, &load_project(project), args).await
                                     }
@@ -560,6 +581,20 @@ async fn list_recipes(client: &AdaptiveClient, project: &str) -> Result<()> {
     element!(RecipeList(recipes: recipes)).print();
 
     Ok(())
+}
+
+async fn delete_recipe(client: &AdaptiveClient, project: &str, recipe: &str) -> Result<()> {
+    let deleted = client.delete_recipe(project, recipe).await?;
+    if deleted {
+        println!("Recipe {} deleted from project {}", recipe, project);
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Recipe {} was not deleted from project {}",
+            recipe,
+            project
+        ))
+    }
 }
 
 fn zip_recipe_dir<P: AsRef<Path>>(


### PR DESCRIPTION
## Summary
- Adds `adpt recipes delete <recipe>` and folds the existing top-level `adpt publish` under `adpt recipes publish` for consistency with the new subcommand group.
- `adpt recipes list` / `adpt recipes publish` / `adpt recipes delete` now share a parent command.
- Depends on `adaptive-client-rust` 0.14.2 (PR adaptive-ml/adaptive#4762) which adds the `deleteCustomRecipe` mutation wrapper.

Closes FE-5