### PR TITLE
Add deployment profiles for switching between deployments

### DIFF
--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -6,7 +6,14 @@ This document contains the help content for the `adpt` command-line program.
 
 * [`adpt`↴](#adpt)
 * [`adpt cancel`↴](#adpt-cancel)
-* [`adpt config`↴](#adpt-config)
+* [`adpt deployment`↴](#adpt-deployment)
+* [`adpt deployment setup`↴](#adpt-deployment-setup)
+* [`adpt deployment list`↴](#adpt-deployment-list)
+* [`adpt deployment show`↴](#adpt-deployment-show)
+* [`adpt deployment use`↴](#adpt-deployment-use)
+* [`adpt deployment current`↴](#adpt-deployment-current)
+* [`adpt deployment remove`↴](#adpt-deployment-remove)
+* [`adpt whoami`↴](#adpt-whoami)
 * [`adpt job`↴](#adpt-job)
 * [`adpt jobs`↴](#adpt-jobs)
 * [`adpt models`↴](#adpt-models)
@@ -15,7 +22,6 @@ This document contains the help content for the `adpt` command-line program.
 * [`adpt recipes`↴](#adpt-recipes)
 * [`adpt run`↴](#adpt-run)
 * [`adpt schema`↴](#adpt-schema)
-* [`adpt set-api-key`↴](#adpt-set-api-key)
 * [`adpt role`↴](#adpt-role)
 * [`adpt role create`↴](#adpt-role-create)
 * [`adpt role describe`↴](#adpt-role-describe)
@@ -37,12 +43,13 @@ This document contains the help content for the `adpt` command-line program.
 
 A tool interacting with the Adaptive platform
 
-**Usage:** `adpt <COMMAND>`
+**Usage:** `adpt [OPTIONS] <COMMAND>`
 
 ###### **Subcommands:**
 
 * `cancel` — Cancel a job
-* `config` — Configure adpt interactively
+* `deployment` — Manage Adaptive deployments
+* `whoami` — Show the active deployment and its resolved settings
 * `job` — Inspect job
 * `jobs` — List currently running jobs
 * `models` — List models
@@ -51,10 +58,13 @@ A tool interacting with the Adaptive platform
 * `recipes` — List recipes
 * `run` — Run recipe
 * `schema` — Display the schema for inputs for a recipe
-* `set-api-key` — Store your API key in the OS keyring
 * `role` — Manage roles
 * `user` — Manage users
 * `team` — Manage teams
+
+###### **Options:**
+
+* `--deployment <DEPLOYMENT>` — Use a specific deployment for this invocation, overriding the active one
 
 
 
@@ -70,11 +80,102 @@ Cancel a job
 
 
 
-## `adpt config`
+## `adpt deployment`
 
-Configure adpt interactively
+Manage Adaptive deployments
 
-**Usage:** `adpt config`
+**Usage:** `adpt deployment <COMMAND>`
+
+###### **Subcommands:**
+
+* `setup` — Create or edit a deployment interactively
+* `list` — List all configured deployments
+* `show` — Show details for a deployment
+* `use` — Set the active deployment
+* `current` — Print just the active deployment name (for shell prompts)
+* `remove` — Remove a deployment and its stored API key
+
+
+
+## `adpt deployment setup`
+
+Create or edit a deployment interactively
+
+**Usage:** `adpt deployment setup [OPTIONS] [NAME]`
+
+###### **Arguments:**
+
+* `<NAME>` — Deployment name. If omitted, edits the active deployment
+
+###### **Options:**
+
+* `--url <URL>` — Skip the dialog by passing the base URL directly
+* `--default-project <DEFAULT_PROJECT>` — Skip the dialog by passing a default project directly
+* `--api-key <API_KEY>` — Skip the dialog by passing the API key directly
+
+
+
+## `adpt deployment list`
+
+List all configured deployments
+
+**Usage:** `adpt deployment list`
+
+
+
+## `adpt deployment show`
+
+Show details for a deployment
+
+**Usage:** `adpt deployment show [NAME]`
+
+###### **Arguments:**
+
+* `<NAME>` — Deployment name. Defaults to the active deployment
+
+
+
+## `adpt deployment use`
+
+Set the active deployment
+
+**Usage:** `adpt deployment use <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Deployment name to activate
+
+
+
+## `adpt deployment current`
+
+Print just the active deployment name (for shell prompts)
+
+**Usage:** `adpt deployment current`
+
+
+
+## `adpt deployment remove`
+
+Remove a deployment and its stored API key
+
+**Usage:** `adpt deployment remove [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Deployment name to remove
+
+###### **Options:**
+
+* `-f`, `--force` — Allow removing the active deployment
+
+
+
+## `adpt whoami`
+
+Show the active deployment and its resolved settings
+
+**Usage:** `adpt whoami`
 
 
 
@@ -199,18 +300,6 @@ Display the schema for inputs for a recipe
 ###### **Options:**
 
 * `-p`, `--project <PROJECT>`
-
-
-
-## `adpt set-api-key`
-
-Store your API key in the OS keyring
-
-**Usage:** `adpt set-api-key <API_KEY>`
-
-###### **Arguments:**
-
-* `<API_KEY>`
 
 
 

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -109,9 +109,9 @@ Create or edit a deployment interactively
 
 ###### **Options:**
 
-* `--url <URL>` — Skip the dialog by passing the base URL directly
-* `--default-project <DEFAULT_PROJECT>` — Skip the dialog by passing a default project directly
-* `--api-key <API_KEY>` — Skip the dialog by passing the API key directly
+* `--url <URL>` — Base URL (for non-interactive setup, e.g. in CI)
+* `--default-project <DEFAULT_PROJECT>` — Default project (for non-interactive setup)
+* `--api-key <API_KEY>` — API key (for non-interactive setup)
 
 
 

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -91,7 +91,7 @@ Manage Adaptive deployments
 * `setup` — Create or edit a deployment interactively
 * `list` — List all configured deployments
 * `show` — Show details for a deployment
-* `use` — Set the active deployment
+* `use` — Pin a shell to a deployment (spawns a subshell with $ADPT_DEPLOYMENT)
 * `current` — Print just the active deployment name (for shell prompts)
 * `remove` — Remove a deployment and its stored API key
 
@@ -137,13 +137,17 @@ Show details for a deployment
 
 ## `adpt deployment use`
 
-Set the active deployment
+Pin a shell to a deployment (spawns a subshell with $ADPT_DEPLOYMENT)
 
-**Usage:** `adpt deployment use <NAME>`
+**Usage:** `adpt deployment use [OPTIONS] <NAME>`
 
 ###### **Arguments:**
 
 * `<NAME>` — Deployment name to activate
+
+###### **Options:**
+
+* `-p`, `--persist` — Also persist as the file-level active deployment for fresh shells
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,20 @@ install via DNF.
 cargo install adpt
 ```
 
-Once installed an API key must be specified for use. This can be done using the
-`ADAPTIVE_API_KEY` environment variable, or alternatively stored in your
-operating system's keyring using the below command:
+Once installed, configure a deployment (URL + API key + optional default
+project) interactively:
 
 ```sh
-adpt set-api-key
+adpt deployment setup prod
 ```
 
-Additionally your adaptive instance may be specified either via the
-`ADAPTIVE_BASE_URL` environment variable or via a configuration file as
-described in the configuration section below.
+You can configure multiple deployments and switch between them with
+`adpt deployment use <name>`. See the [Deployments](#deployments) section
+below.
+
+Environment variables (`ADAPTIVE_API_KEY`, `ADAPTIVE_BASE_URL`,
+`DEFAULT_PROJECT`) still work and override the active deployment's values
+on a per-invocation basis.
 
 ### Completions
 
@@ -66,14 +69,6 @@ adpt recipes --project my-project
 
 However to avoid specifying this every time, the `DEFAULT_PROJECT` environment
 variable or the `default_project` configuration file option.:
-
-### Setting API Key
-
-Store your API key in the system keyring:
-
-```sh
-adpt set-api-key <your-api-key>
-```
 
 ### Full command reference
 
@@ -105,15 +100,68 @@ parameter to another:
 adpt publish my_recipe.py | xargs -I {} adpt run {}
 ```
 
+## Deployments
+
+A deployment bundles a base URL, an API key (stored in the OS keyring), and
+an optional default project. You can configure several and switch between
+them.
+
+```sh
+adpt deployment setup prod         # interactive create/edit
+adpt deployment setup staging
+adpt deployment list               # see them all; the active one is marked
+adpt deployment use staging        # switch
+adpt deployment current            # print just the active name
+adpt whoami                        # active deployment + resolved settings
+adpt --deployment prod recipes     # one-off override without switching
+adpt deployment remove staging     # delete it (and its API key)
+```
+
+Legacy flat configs (pre-FE-26) are migrated automatically into a
+`default` deployment on first run.
+
+### Shell prompt integration
+
+`adpt deployment current` is fast and pipe-friendly — wrap it in your
+prompt to always see which deployment you're talking to. Bash/zsh:
+
+```sh
+# in ~/.bashrc or ~/.zshrc
+adpt_prompt() {
+  local d
+  d=$(adpt deployment current 2>/dev/null) && [ -n "$d" ] && printf ' (adpt:%s)' "$d"
+}
+PS1='\u@\h \w$(adpt_prompt)\$ '   # bash
+# zsh:  PROMPT='%n@%m %~$(adpt_prompt)%# '
+```
+
+Fish:
+
+```fish
+function fish_right_prompt
+  set -l d (adpt deployment current 2>/dev/null)
+  test -n "$d"; and echo "adpt:$d"
+end
+```
+
+Starship/oh-my-posh users can point a `custom` segment at
+`adpt deployment current`.
+
 ## Configuration
 
-### Env file
+### Env file overrides
 
-Environment variables may be specified using a `.env` file in a parent folder.
+Environment variables in a `.env` file in the current directory (or any
+parent) override individual fields of the active deployment:
 
-### Configuration File Locations
+- `ADAPTIVE_BASE_URL` — overrides the base URL
+- `ADAPTIVE_API_KEY` — overrides the keyring-stored key
+- `DEFAULT_PROJECT` — overrides the default project
 
-Configuration files are stored in platform-specific locations:
+This makes it easy to pin a repo to a particular Adaptive instance without
+switching your global active deployment.
+
+### Configuration file locations
 
 | Platform    | Configuration File Path                                             |
 | ----------- | ------------------------------------------------------------------- |
@@ -121,21 +169,17 @@ Configuration files are stored in platform-specific locations:
 | **macOS**   | `~/.adpt/config.toml`                                               |
 | **Windows** | `%APPDATA%\adaptive-ml\adpt\config\config.toml`                     |
 
-### Configuration File Format
-
-The configuration file uses TOML format and supports the following options:
+### Configuration file format
 
 ```toml
-# Default project for operations
+active_deployment = "prod"
+
+[deployments.prod]
+adaptive_base_url = "https://prod.adaptive.example"
 default_project = "my-project"
 
-# Base URL for the Adaptive platform
-adaptive_base_url = "https://your-adaptive-instance.com"
+[deployments.staging]
+adaptive_base_url = "https://staging.adaptive.example"
 ```
 
-### API Key Storage
-
-The API key can be provided in two ways (in order of priority):
-
-1. **Environment Variable**: Set `ADAPTIVE_API_KEY` environment variable
-2. **System Keyring**: Store securely using `adpt set-api-key <your-key>`
+API keys are stored per-deployment in the OS keyring, never in this file.

--- a/README.md
+++ b/README.md
@@ -109,57 +109,47 @@ them.
 ```sh
 adpt deployment setup prod         # interactive create/edit
 adpt deployment setup staging
-adpt deployment list               # see them all; the active one is marked
-adpt deployment use staging        # switch
-adpt deployment current            # print just the active name
+adpt deployment list               # see them all
+adpt deployment show prod          # see the details of one
+adpt deployment use staging        # pin this shell to staging
+adpt deployment use prod --persist # pin this shell AND make prod the default for new shells
+adpt deployment current            # print the deployment this shell sees
 adpt whoami                        # active deployment + resolved settings
-adpt --deployment prod recipes     # one-off override without switching
+adpt --deployment prod recipes     # one-off override for a single command
 adpt deployment remove staging     # delete it (and its API key)
 ```
 
-Legacy flat configs (pre-FE-26) are migrated automatically into a
-`default` deployment on first run.
+### How switching works
+
+`adpt deployment use` spawns a new shell with `$ADPT_DEPLOYMENT` exported.
+
+If you want a switch that does propagate to fresh shells, add `--persist`
+(or use `setup`, which always persists). Persisting writes the
+file-level `active_deployment` in `~/.adpt/config.toml`.
+
+Resolution order for every command:
+
+1. `--deployment <name>` flag
+2. `$ADPT_DEPLOYMENT` env var (your current shell)
+3. `active_deployment` in the config file (the file-level default)
 
 ### Shell prompt integration
 
-`adpt deployment current` is fast and pipe-friendly — wrap it in your
-prompt to always see which deployment you're talking to. Bash/zsh:
-
-```sh
-# in ~/.bashrc or ~/.zshrc
-adpt_prompt() {
-  local d
-  d=$(adpt deployment current 2>/dev/null) && [ -n "$d" ] && printf ' (adpt:%s)' "$d"
-}
-PS1='\u@\h \w$(adpt_prompt)\$ '   # bash
-# zsh:  PROMPT='%n@%m %~$(adpt_prompt)%# '
-```
-
-Fish:
-
-```fish
-function fish_right_prompt
-  set -l d (adpt deployment current 2>/dev/null)
-  test -n "$d"; and echo "adpt:$d"
-end
-```
-
-Starship/oh-my-posh users can point a `custom` segment at
-`adpt deployment current`.
+You can configure your shell prompt to show the active deployment by
+printing the output of `adpt deployment current` in it.
 
 ## Configuration
 
-### Env file overrides
+### Env vars and `.env` overrides
 
-Environment variables in a `.env` file in the current directory (or any
-parent) override individual fields of the active deployment:
+Environment variables, from the shell or a `.env` file in the current
+directory (or any parent), override the deployment selection and its
+fields on a per-invocation basis:
 
-- `ADAPTIVE_BASE_URL` — overrides the base URL
-- `ADAPTIVE_API_KEY` — overrides the keyring-stored key
-- `DEFAULT_PROJECT` — overrides the default project
-
-This makes it easy to pin a repo to a particular Adaptive instance without
-switching your global active deployment.
+- `ADPT_DEPLOYMENT`: pins the deployment to use (same as `--deployment`)
+- `ADAPTIVE_BASE_URL`: overrides the base URL
+- `ADAPTIVE_API_KEY`: overrides the keyring-stored key
+- `DEFAULT_PROJECT`: overrides the default project
 
 ### Configuration file locations
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,13 +130,30 @@ fn migrate_legacy_keyring() -> Result<()> {
     Ok(())
 }
 
-/// Resolve the active deployment, honoring an optional override.
-/// Falls back to the sole deployment if exactly one exists.
+/// Resolve the active deployment.
+///
+/// Order of precedence:
+///   1. explicit `--deployment` override
+///   2. `$ADPT_DEPLOYMENT` env var (pins a shell, kubie-style)
+///   3. `active_deployment` field in the config file
+///   4. sole configured deployment if exactly one exists
 fn resolve_active_name(file: &ConfigFile, override_name: Option<&str>) -> Result<String> {
     if let Some(name) = override_name {
         let name = normalize_name(name);
         if !file.deployments.contains_key(&name) {
             bail!("Deployment `{name}` is not configured. Run `adpt deployment setup {name}`.");
+        }
+        return Ok(name);
+    }
+    if let Ok(env_name) = std::env::var("ADPT_DEPLOYMENT")
+        && !env_name.is_empty()
+    {
+        let name = normalize_name(&env_name);
+        if !file.deployments.contains_key(&name) {
+            bail!(
+                "Deployment `{name}` (from $ADPT_DEPLOYMENT) is not configured. \
+                 Run `adpt deployment setup {name}` or unset the env var."
+            );
         }
         return Ok(name);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,16 @@ use anyhow::{Context, Result, anyhow, bail};
 use dotenvy::dotenv;
 use keyring::Entry;
 use serde::{Deserialize, Serialize};
+use slug::slugify;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use url::Url;
+
+/// Normalize a user-provided deployment name into a stable slug.
+pub fn normalize_name(name: &str) -> String {
+    slugify(name)
+}
 
 pub const KEYRING_SERVICE: &str = "adpt-api-key";
 const LEGACY_KEYRING_USER: &str = "Adaptive";
@@ -128,10 +134,11 @@ fn migrate_legacy_keyring() -> Result<()> {
 /// Falls back to the sole deployment if exactly one exists.
 fn resolve_active_name(file: &ConfigFile, override_name: Option<&str>) -> Result<String> {
     if let Some(name) = override_name {
-        if !file.deployments.contains_key(name) {
+        let name = normalize_name(name);
+        if !file.deployments.contains_key(&name) {
             bail!("Deployment `{name}` is not configured. Run `adpt deployment setup {name}`.");
         }
-        return Ok(name.to_string());
+        return Ok(name);
     }
     if let Some(name) = &file.active_deployment
         && file.deployments.contains_key(name)
@@ -218,39 +225,42 @@ pub fn delete_api_key(deployment: &str) -> Result<()> {
 }
 
 pub fn upsert_deployment(name: &str, deployment: DeploymentConfig) -> Result<()> {
+    let name = normalize_name(name);
     let mut file = read_config_file()?;
-    let was_empty = file.deployments.is_empty();
-    file.deployments.insert(name.to_string(), deployment);
-    if was_empty || file.active_deployment.is_none() {
-        file.active_deployment = Some(name.to_string());
+    let is_new = !file.deployments.contains_key(&name);
+    file.deployments.insert(name.clone(), deployment);
+    if is_new {
+        file.active_deployment = Some(name);
     }
     write_config_file(&file)
 }
 
 pub fn set_active(name: &str) -> Result<()> {
+    let name = normalize_name(name);
     let mut file = read_config_file()?;
-    if !file.deployments.contains_key(name) {
+    if !file.deployments.contains_key(&name) {
         bail!("Deployment `{name}` is not configured.");
     }
-    file.active_deployment = Some(name.to_string());
+    file.active_deployment = Some(name);
     write_config_file(&file)
 }
 
 pub fn remove_deployment(name: &str, force: bool) -> Result<()> {
+    let name = normalize_name(name);
     let mut file = read_config_file()?;
-    if !file.deployments.contains_key(name) {
+    if !file.deployments.contains_key(&name) {
         bail!("Deployment `{name}` is not configured.");
     }
-    if file.active_deployment.as_deref() == Some(name) && !force {
+    if file.active_deployment.as_deref() == Some(name.as_str()) && !force {
         bail!(
             "`{name}` is the active deployment. Use --force or switch first with `adpt deployment use <other>`."
         );
     }
-    file.deployments.remove(name);
-    if file.active_deployment.as_deref() == Some(name) {
+    file.deployments.remove(&name);
+    if file.active_deployment.as_deref() == Some(name.as_str()) {
         file.active_deployment = file.deployments.keys().next().cloned();
     }
     write_config_file(&file)?;
-    delete_api_key(name)?;
+    delete_api_key(&name)?;
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,45 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use dotenvy::dotenv;
 use keyring::Entry;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use url::Url;
 
 pub const KEYRING_SERVICE: &str = "adpt-api-key";
-pub const KEYRING_USER: &str = "Adaptive";
+const LEGACY_KEYRING_USER: &str = "Adaptive";
+
+fn keyring_user(deployment: &str) -> String {
+    format!("Adaptive:{deployment}")
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct DeploymentConfig {
+    pub adaptive_base_url: Url,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_project: Option<String>,
+}
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ConfigFile {
-    pub default_project: Option<String>,
-    pub adaptive_base_url: Option<Url>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_deployment: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub deployments: BTreeMap<String, DeploymentConfig>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ConfigFileRaw {
+    #[serde(default)]
+    active_deployment: Option<String>,
+    #[serde(default)]
+    deployments: BTreeMap<String, DeploymentConfig>,
+    // Legacy flat fields, present in pre-FE-26 configs.
+    #[serde(default)]
+    adaptive_base_url: Option<Url>,
+    #[serde(default)]
+    default_project: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -23,39 +50,10 @@ struct ConfigEnv {
 }
 
 pub struct Config {
+    pub deployment_name: String,
     pub default_project: Option<String>,
     pub adaptive_base_url: Url,
     pub adaptive_api_key: String,
-}
-
-fn merge_config(base: ConfigFile, override_config: ConfigEnv) -> Result<Config> {
-    let default_project = override_config.default_project.or(base.default_project);
-
-    let mut adaptive_base_url = override_config
-        .adaptive_base_url
-        .or(base.adaptive_base_url)
-        .ok_or(anyhow!("No adaptive base URL provided"))?;
-
-    adaptive_base_url = adaptive_base_url
-        .join("/api/")
-        .context("Failed to append /api to base URL")?;
-
-    let adaptive_api_key = if let Some(api_key) = override_config.adaptive_api_key {
-        api_key
-    } else {
-        let entry = Entry::new(KEYRING_SERVICE, KEYRING_USER)?;
-        let api_key = entry.get_secret().context(
-            "API key not specified via environment variable nor present in OS keyring.\n\
-            Use `adpt set-api-key <your-key>` to set it.",
-        )?;
-        String::from_utf8(api_key)?
-    };
-
-    Ok(Config {
-        default_project,
-        adaptive_base_url,
-        adaptive_api_key,
-    })
 }
 
 fn get_config_file_path() -> Result<PathBuf> {
@@ -74,37 +72,185 @@ fn get_config_file_path() -> Result<PathBuf> {
     }
 }
 
-pub fn read_config() -> Result<Config> {
-    let _ = dotenv();
-    let env_config = envy::from_env::<ConfigEnv>().unwrap_or_default();
+/// Read the config file from disk and apply legacy migration in-memory.
+/// If a legacy flat config is detected, this also persists the migrated form
+/// and moves the keyring entry from `Adaptive` to `Adaptive:default`.
+pub fn read_config_file() -> Result<ConfigFile> {
+    let path = get_config_file_path()?;
+    let Ok(raw_str) = fs::read_to_string(&path) else {
+        return Ok(ConfigFile::default());
+    };
+    let raw: ConfigFileRaw = toml::from_str(&raw_str)?;
 
-    let config_file = get_config_file_path()?;
-    let file_config = if let Ok(config) = fs::read_to_string(config_file) {
-        toml::from_str(&config)?
-    } else {
-        ConfigFile::default()
+    let needs_migration = raw.deployments.is_empty() && raw.adaptive_base_url.is_some();
+
+    let mut file = ConfigFile {
+        active_deployment: raw.active_deployment,
+        deployments: raw.deployments,
     };
 
-    merge_config(file_config, env_config)
+    if needs_migration && let Some(url) = raw.adaptive_base_url {
+        file.deployments.insert(
+            "default".to_string(),
+            DeploymentConfig {
+                adaptive_base_url: url,
+                default_project: raw.default_project,
+            },
+        );
+        file.active_deployment = Some("default".to_string());
+        write_config_file(&file)?;
+        let _ = migrate_legacy_keyring();
+    }
+
+    Ok(file)
 }
 
-pub fn set_api_key_keyring(api_key: String) -> Result<()> {
-    let entry = Entry::new(KEYRING_SERVICE, KEYRING_USER)?;
-    entry.set_secret(api_key.as_bytes())?;
-    println!("API key set for use with adpt");
+pub fn write_config_file(config: &ConfigFile) -> Result<()> {
+    let path = get_config_file_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let toml_string = toml::to_string_pretty(config)?;
+    fs::write(&path, toml_string)?;
     Ok(())
 }
 
-pub fn write_config(config: ConfigFile) -> Result<()> {
-    let config_file_path = get_config_file_path()?;
+fn migrate_legacy_keyring() -> Result<()> {
+    let legacy = Entry::new(KEYRING_SERVICE, LEGACY_KEYRING_USER)?;
+    let secret = legacy.get_secret()?;
+    let new = Entry::new(KEYRING_SERVICE, &keyring_user("default"))?;
+    new.set_secret(&secret)?;
+    let _ = legacy.delete_credential();
+    Ok(())
+}
 
-    if let Some(parent) = config_file_path.parent() {
-        fs::create_dir_all(parent)?;
+/// Resolve the active deployment, honoring an optional override.
+/// Falls back to the sole deployment if exactly one exists.
+fn resolve_active_name(file: &ConfigFile, override_name: Option<&str>) -> Result<String> {
+    if let Some(name) = override_name {
+        if !file.deployments.contains_key(name) {
+            bail!("Deployment `{name}` is not configured. Run `adpt deployment setup {name}`.");
+        }
+        return Ok(name.to_string());
     }
+    if let Some(name) = &file.active_deployment
+        && file.deployments.contains_key(name)
+    {
+        return Ok(name.clone());
+    }
+    if file.deployments.len() == 1 {
+        return Ok(file.deployments.keys().next().unwrap().clone());
+    }
+    if file.deployments.is_empty() {
+        bail!("No deployment configured. Run `adpt deployment setup <name>`.");
+    }
+    bail!(
+        "No active deployment selected. Run `adpt deployment use <name>` (configured: {}).",
+        file.deployments
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+}
 
-    let toml_string = toml::to_string_pretty(&config)?;
-    fs::write(&config_file_path, toml_string)?;
+pub fn read_config(deployment_override: Option<&str>) -> Result<Config> {
+    let _ = dotenv();
+    let env_config = envy::from_env::<ConfigEnv>().unwrap_or_default();
+    let file = read_config_file()?;
+    let name = resolve_active_name(&file, deployment_override)?;
+    let base = file
+        .deployments
+        .get(&name)
+        .cloned()
+        .ok_or_else(|| anyhow!("Deployment `{name}` not found"))?;
 
-    println!("\nConfiguration saved to {}", config_file_path.display());
+    let default_project = env_config.default_project.or(base.default_project);
+
+    let mut adaptive_base_url = env_config
+        .adaptive_base_url
+        .unwrap_or(base.adaptive_base_url);
+    adaptive_base_url = adaptive_base_url
+        .join("/api/")
+        .context("Failed to append /api to base URL")?;
+
+    let adaptive_api_key = if let Some(api_key) = env_config.adaptive_api_key {
+        api_key
+    } else {
+        get_api_key(&name)?.ok_or_else(|| {
+            anyhow!(
+                "API key for deployment `{name}` not found in OS keyring.\n\
+                 Run `adpt deployment setup {name}` to set it."
+            )
+        })?
+    };
+
+    Ok(Config {
+        deployment_name: name,
+        default_project,
+        adaptive_base_url,
+        adaptive_api_key,
+    })
+}
+
+pub fn get_api_key(deployment: &str) -> Result<Option<String>> {
+    let entry = Entry::new(KEYRING_SERVICE, &keyring_user(deployment))?;
+    match entry.get_secret() {
+        Ok(bytes) => Ok(Some(String::from_utf8(bytes)?)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn set_api_key(deployment: &str, api_key: &str) -> Result<()> {
+    let entry = Entry::new(KEYRING_SERVICE, &keyring_user(deployment))?;
+    entry.set_secret(api_key.as_bytes())?;
+    Ok(())
+}
+
+pub fn delete_api_key(deployment: &str) -> Result<()> {
+    let entry = Entry::new(KEYRING_SERVICE, &keyring_user(deployment))?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn upsert_deployment(name: &str, deployment: DeploymentConfig) -> Result<()> {
+    let mut file = read_config_file()?;
+    let was_empty = file.deployments.is_empty();
+    file.deployments.insert(name.to_string(), deployment);
+    if was_empty || file.active_deployment.is_none() {
+        file.active_deployment = Some(name.to_string());
+    }
+    write_config_file(&file)
+}
+
+pub fn set_active(name: &str) -> Result<()> {
+    let mut file = read_config_file()?;
+    if !file.deployments.contains_key(name) {
+        bail!("Deployment `{name}` is not configured.");
+    }
+    file.active_deployment = Some(name.to_string());
+    write_config_file(&file)
+}
+
+pub fn remove_deployment(name: &str, force: bool) -> Result<()> {
+    let mut file = read_config_file()?;
+    if !file.deployments.contains_key(name) {
+        bail!("Deployment `{name}` is not configured.");
+    }
+    if file.active_deployment.as_deref() == Some(name) && !force {
+        bail!(
+            "`{name}` is the active deployment. Use --force or switch first with `adpt deployment use <other>`."
+        );
+    }
+    file.deployments.remove(name);
+    if file.active_deployment.as_deref() == Some(name) {
+        file.active_deployment = file.deployments.keys().next().cloned();
+    }
+    write_config_file(&file)?;
+    delete_api_key(name)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,11 +29,12 @@ use zip_extensions::{
 };
 
 use crate::{
+    config::DeploymentConfig,
     json_schema::{JsonSchema, JsonSchemaPropertyContents},
     terminal::TitleGuard,
     ui::{
         AllModelsList, Cell, Column, ConfigHeader, ErrorMessage, InputPrompt, JobsList, ListConfig,
-        ModelsList, ProgressBar, RecipeList, SuccessMessage, render_list,
+        ModelsList, ProgressBar, RecipeList, SuccessMessage, deployment_color, render_list,
     },
 };
 
@@ -51,6 +52,9 @@ const DEFAULT_ADAPTIVE_BASE_URL: &str = "https://app.adaptive.ml";
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+    /// Use a specific deployment for this invocation, overriding the active one
+    #[arg(long, global = true)]
+    deployment: Option<String>,
     #[arg(long, hide = true)]
     markdown_help: bool,
 }
@@ -187,11 +191,56 @@ enum TeamCommands {
 }
 
 #[derive(Subcommand)]
+enum DeploymentCommands {
+    /// Create or edit a deployment interactively
+    Setup {
+        /// Deployment name. If omitted, edits the active deployment.
+        name: Option<String>,
+        /// Skip the dialog by passing the base URL directly
+        #[arg(long)]
+        url: Option<Url>,
+        /// Skip the dialog by passing a default project directly
+        #[arg(long)]
+        default_project: Option<String>,
+        /// Skip the dialog by passing the API key directly
+        #[arg(long)]
+        api_key: Option<String>,
+    },
+    /// List all configured deployments
+    List,
+    /// Show details for a deployment
+    Show {
+        /// Deployment name. Defaults to the active deployment.
+        name: Option<String>,
+    },
+    /// Set the active deployment
+    Use {
+        /// Deployment name to activate
+        name: String,
+    },
+    /// Print just the active deployment name (for shell prompts)
+    Current,
+    /// Remove a deployment and its stored API key
+    Remove {
+        /// Deployment name to remove
+        name: String,
+        /// Allow removing the active deployment
+        #[arg(short, long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum Commands {
     /// Cancel a job
     Cancel { id: Uuid },
-    /// Configure adpt interactively
-    Config,
+    /// Manage Adaptive deployments
+    Deployment {
+        #[command(subcommand)]
+        command: DeploymentCommands,
+    },
+    /// Show the active deployment and its resolved settings
+    Whoami,
     /// Inspect job
     Job {
         id: Uuid,
@@ -260,8 +309,6 @@ enum Commands {
         #[arg(add = ArgValueCompleter::new(recipe_key_completer))]
         recipe: String,
     },
-    /// Store your API key in the OS keyring
-    SetApiKey { api_key: String },
     /// Manage roles
     Role {
         #[command(subcommand)]
@@ -283,7 +330,8 @@ impl Commands {
     fn name(&self) -> &'static str {
         match self {
             Commands::Cancel { .. } => "cancel",
-            Commands::Config => "config",
+            Commands::Deployment { .. } => "deployment",
+            Commands::Whoami => "whoami",
             Commands::Job { .. } => "job",
             Commands::Jobs => "jobs",
             Commands::Models { .. } => "models",
@@ -292,7 +340,6 @@ impl Commands {
             Commands::Recipes { .. } => "recipes",
             Commands::Run { .. } => "run",
             Commands::Schema { .. } => "schema",
-            Commands::SetApiKey { .. } => "set-api-key",
             Commands::Role { .. } => "role",
             Commands::User { .. } => "user",
             Commands::Team { .. } => "team",
@@ -323,12 +370,16 @@ fn main() -> Result<()> {
     }
     let _title_guard = TitleGuard::new(&format!("adpt - {}", cli.command.name()));
 
+    let deployment_override = cli.deployment.clone();
     rt.block_on(async {
         match cli.command {
-            Commands::Config => interactive_config(),
-            Commands::SetApiKey { api_key } => config::set_api_key_keyring(api_key),
+            Commands::Deployment { command } => {
+                handle_deployment_command(command, deployment_override.as_deref())
+            }
+            Commands::Whoami => print_whoami(deployment_override.as_deref()),
             requires_api_key => {
-                let config = config::read_config()?;
+                ensure_deployment_configured()?;
+                let config = config::read_config(deployment_override.as_deref())?;
                 let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
                 let default_project = config.default_project.clone();
 
@@ -370,8 +421,8 @@ fn main() -> Result<()> {
                     Commands::Schema { project, recipe } => {
                                         print_schema(&client, load_project(project), recipe).await
                                     }
-                    Commands::Config => panic!("This state should be unreachable"),
-                    Commands::SetApiKey { api_key: _ } => panic!("This state should be unreachable"),
+                    Commands::Deployment { .. } => panic!("This state should be unreachable"),
+                    Commands::Whoami => panic!("This state should be unreachable"),
                     Commands::Upload { project, dataset, name } => upload_dataset(&client, &load_project(project), dataset, name).await,
                     Commands::Role { command } => match command {
                         RoleCommands::Create { name, key, permissions } => {
@@ -704,14 +755,19 @@ fn recipe_key_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         return completions;
     };
 
-    let config = config::read_config().expect("Failed to read config");
+    let Ok(config) = config::read_config(None) else {
+        return completions;
+    };
+    let Some(default_project) = config.default_project else {
+        return completions;
+    };
 
     let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
-    let recipes = handle
-        .block_on(client.list_recipes(&config.default_project.expect("No default project set")))
-        .unwrap();
+    let Ok(recipes) = handle.block_on(client.list_recipes(&default_project)) else {
+        return completions;
+    };
 
     recipes.into_iter().for_each(|recipe| {
         if let Some(key) = recipe.key
@@ -730,12 +786,16 @@ fn project_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         return completions;
     };
 
-    let config = config::read_config().expect("Failed to read config");
+    let Ok(config) = config::read_config(None) else {
+        return completions;
+    };
 
     let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
-    let projects = handle.block_on(client.list_projects()).unwrap();
+    let Ok(projects) = handle.block_on(client.list_projects()) else {
+        return completions;
+    };
 
     projects.into_iter().for_each(|project| {
         if project.key.starts_with(current) {
@@ -752,12 +812,16 @@ fn pool_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         return completions;
     };
 
-    let config = config::read_config().expect("Failed to read config");
+    let Ok(config) = config::read_config(None) else {
+        return completions;
+    };
 
     let client = build_adaptive_client(config.adaptive_base_url, config.adaptive_api_key);
 
     let handle = Handle::current();
-    let pools = handle.block_on(client.list_pools()).unwrap();
+    let Ok(pools) = handle.block_on(client.list_pools()) else {
+        return completions;
+    };
 
     pools.into_iter().for_each(|pool| {
         if pool.key.starts_with(current) {
@@ -1274,61 +1338,323 @@ fn read_input(prompt: &str, default: Option<&str>, description: Option<&str>) ->
     }
 }
 
-fn interactive_config() -> Result<()> {
-    element!(ConfigHeader()).print();
-
-    let adaptive_base_url = loop {
-        let base_url_str = read_input(
-            "Adaptive Base URL",
-            Some(DEFAULT_ADAPTIVE_BASE_URL),
-            Some("The base URL for your Adaptive instance"),
+/// Prompt for a deployment name when none was provided. Returns the resolved name.
+fn resolve_setup_target(provided: Option<String>) -> Result<(String, Option<DeploymentConfig>)> {
+    let file = config::read_config_file()?;
+    let name = if let Some(name) = provided {
+        name
+    } else if let Some(active) = file.active_deployment.clone() {
+        active
+    } else {
+        let entered = read_input(
+            "Deployment name",
+            Some("default"),
+            Some("A short label for this Adaptive deployment (e.g. prod, staging)"),
         )?;
+        if entered.is_empty() {
+            bail!("Deployment name cannot be empty");
+        }
+        entered
+    };
+    let existing = file.deployments.get(&name).cloned();
+    Ok((name, existing))
+}
 
-        match Url::parse(&base_url_str) {
-            Ok(url) => break url,
-            Err(e) => {
-                element!(ErrorMessage(message: format!("Invalid URL: {}", e))).print();
-                println!();
+fn deployment_setup(
+    name: Option<String>,
+    url: Option<Url>,
+    default_project: Option<String>,
+    api_key: Option<String>,
+) -> Result<()> {
+    let (name, existing) = resolve_setup_target(name)?;
+    let is_edit = existing.is_some();
+
+    let title = if is_edit {
+        format!("⚙️  Edit deployment: {name}")
+    } else {
+        format!("⚙️  Set up deployment: {name}")
+    };
+    element!(ConfigHeader(title: Some(title), subtitle: None)).print();
+
+    let interactive = url.is_none() && api_key.is_none() && io::stdout().is_terminal();
+
+    // Resolve base URL
+    let adaptive_base_url = if let Some(u) = url {
+        u
+    } else if interactive {
+        let default = existing
+            .as_ref()
+            .map(|d| d.adaptive_base_url.to_string())
+            .unwrap_or_else(|| DEFAULT_ADAPTIVE_BASE_URL.to_string());
+        loop {
+            let entered = read_input(
+                "Adaptive Base URL",
+                Some(&default),
+                Some("The base URL for your Adaptive instance"),
+            )?;
+            match Url::parse(&entered) {
+                Ok(url) => break url,
+                Err(e) => {
+                    element!(ErrorMessage(message: format!("Invalid URL: {}", e))).print();
+                    println!();
+                }
             }
         }
-    };
-
-    let adaptive_api_key = loop {
-        let api_key = read_input(
-            "API Key",
-            None,
-            Some("Your Adaptive API key (stored securely in OS keyring)"),
-        )?;
-
-        if api_key.is_empty() {
-            element!(ErrorMessage(message: "API key cannot be empty".to_string())).print();
-            println!();
-        } else {
-            break api_key;
-        }
-    };
-
-    let default_project_str = read_input(
-        "Default Use Case",
-        None,
-        Some("Optional: Set a default project to avoid specifying --project every time"),
-    )?;
-    let default_project = if default_project_str.is_empty() {
-        None
+    } else if let Some(d) = &existing {
+        d.adaptive_base_url.clone()
     } else {
-        Some(default_project_str)
+        bail!("--url is required when running non-interactively for a new deployment");
     };
 
-    config::set_api_key_keyring(adaptive_api_key)?;
-
-    let config_file = config::ConfigFile {
-        adaptive_base_url: Some(adaptive_base_url),
-        default_project,
+    // Resolve API key
+    let api_key_value: Option<String> = if let Some(k) = api_key {
+        Some(k)
+    } else if interactive {
+        let key_existed = config::get_api_key(&name)?.is_some();
+        let description = if key_existed {
+            "Your Adaptive API key (leave blank to keep the existing one)"
+        } else {
+            "Your Adaptive API key (stored securely in OS keyring)"
+        };
+        let entered = read_input("API Key", None, Some(description))?;
+        if entered.is_empty() {
+            if !key_existed && !is_edit {
+                element!(ErrorMessage(
+                    message: "API key required for a new deployment".to_string()
+                ))
+                .print();
+                bail!("Aborted");
+            }
+            None
+        } else {
+            Some(entered)
+        }
+    } else {
+        None
     };
 
-    config::write_config(config_file)?;
+    // Resolve default project
+    let default_project_value: Option<String> = if let Some(p) = default_project {
+        if p.is_empty() { None } else { Some(p) }
+    } else if interactive {
+        let default = existing.as_ref().and_then(|d| d.default_project.clone());
+        let entered = read_input(
+            "Default project",
+            default.as_deref(),
+            Some("Optional: avoids needing --project on every command"),
+        )?;
+        if entered.is_empty() {
+            None
+        } else {
+            Some(entered)
+        }
+    } else {
+        existing.as_ref().and_then(|d| d.default_project.clone())
+    };
 
-    element!(SuccessMessage(message: "Configuration complete!".to_string())).print();
+    config::upsert_deployment(
+        &name,
+        DeploymentConfig {
+            adaptive_base_url,
+            default_project: default_project_value,
+        },
+    )?;
+    if let Some(key) = api_key_value {
+        config::set_api_key(&name, &key)?;
+    }
 
+    let action = if is_edit { "updated" } else { "saved" };
+    element!(SuccessMessage(
+        message: format!("Deployment `{name}` {action}.")
+    ))
+    .print();
     Ok(())
+}
+
+fn handle_deployment_command(
+    command: DeploymentCommands,
+    deployment_override: Option<&str>,
+) -> Result<()> {
+    match command {
+        DeploymentCommands::Setup {
+            name,
+            url,
+            default_project,
+            api_key,
+        } => deployment_setup(name, url, default_project, api_key),
+        DeploymentCommands::List => deployment_list(),
+        DeploymentCommands::Show { name } => deployment_show(name.as_deref(), deployment_override),
+        DeploymentCommands::Use { name } => {
+            config::set_active(&name)?;
+            element!(SuccessMessage(
+                message: format!("Active deployment set to `{name}`.")
+            ))
+            .print();
+            Ok(())
+        }
+        DeploymentCommands::Current => deployment_current(deployment_override),
+        DeploymentCommands::Remove { name, force } => {
+            config::remove_deployment(&name, force)?;
+            element!(SuccessMessage(
+                message: format!("Deployment `{name}` removed.")
+            ))
+            .print();
+            Ok(())
+        }
+    }
+}
+
+fn deployment_list() -> Result<()> {
+    let file = config::read_config_file()?;
+    if file.deployments.is_empty() {
+        println!("No deployments configured. Run `adpt deployment setup <name>`.");
+        return Ok(());
+    }
+    let active = file.active_deployment.as_deref();
+    let is_tty = io::stdout().is_terminal();
+    for (name, cfg) in &file.deployments {
+        let marker = if active == Some(name.as_str()) {
+            "*"
+        } else {
+            " "
+        };
+        if is_tty {
+            element! {
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: format!("{marker} "))
+                    Text(content: name.clone(), color: deployment_color(name), weight: Weight::Bold)
+                    Text(content: format!("  {}", cfg.adaptive_base_url), color: Color::DarkGrey)
+                }
+            }
+            .print();
+        } else {
+            println!("{marker} {name}\t{}", cfg.adaptive_base_url);
+        }
+    }
+    Ok(())
+}
+
+fn deployment_show(name: Option<&str>, deployment_override: Option<&str>) -> Result<()> {
+    let file = config::read_config_file()?;
+    let target = name
+        .map(str::to_string)
+        .or_else(|| deployment_override.map(str::to_string))
+        .or_else(|| file.active_deployment.clone())
+        .ok_or_else(|| anyhow!("No deployment specified and none active."))?;
+    let cfg = file
+        .deployments
+        .get(&target)
+        .ok_or_else(|| anyhow!("Deployment `{target}` is not configured."))?;
+    let key_present = config::get_api_key(&target)?.is_some();
+    let is_tty = io::stdout().is_terminal();
+    if is_tty {
+        element! {
+            View(flex_direction: FlexDirection::Column) {
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: "Deployment: ", weight: Weight::Bold)
+                    Text(content: target.clone(), color: deployment_color(&target), weight: Weight::Bold)
+                }
+                Text(content: format!("URL:             {}", cfg.adaptive_base_url))
+                Text(content: format!(
+                    "Default project: {}",
+                    cfg.default_project.clone().unwrap_or_else(|| "<none>".to_string())
+                ))
+                Text(content: format!("API key:         {}", if key_present { "set" } else { "not set" }))
+            }
+        }
+        .print();
+    } else {
+        println!("name\t{target}");
+        println!("url\t{}", cfg.adaptive_base_url);
+        println!(
+            "default_project\t{}",
+            cfg.default_project.clone().unwrap_or_default()
+        );
+        println!("api_key\t{}", if key_present { "set" } else { "unset" });
+    }
+    Ok(())
+}
+
+fn deployment_current(deployment_override: Option<&str>) -> Result<()> {
+    let file = config::read_config_file()?;
+    let name = if let Some(o) = deployment_override {
+        o.to_string()
+    } else if let Some(a) = file.active_deployment.clone() {
+        a
+    } else if file.deployments.len() == 1 {
+        file.deployments.keys().next().unwrap().clone()
+    } else {
+        // Empty output (no trailing newline) is more shell-prompt friendly.
+        return Ok(());
+    };
+    if io::stdout().is_terminal() {
+        element! {
+            Text(content: name.clone(), color: deployment_color(&name), weight: Weight::Bold)
+        }
+        .print();
+    } else {
+        // No ANSI when piped — prompts that wrap this command will add their own styling.
+        print!("{name}");
+        io::stdout().flush()?;
+    }
+    Ok(())
+}
+
+fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
+    let config = config::read_config(deployment_override)?;
+    let is_tty = io::stdout().is_terminal();
+    if is_tty {
+        element! {
+            View(flex_direction: FlexDirection::Column) {
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: "Active deployment: ", weight: Weight::Bold)
+                    Text(
+                        content: config.deployment_name.clone(),
+                        color: deployment_color(&config.deployment_name),
+                        weight: Weight::Bold,
+                    )
+                }
+                Text(content: format!("URL:               {}", config.adaptive_base_url))
+                Text(content: format!(
+                    "Default project:   {}",
+                    config.default_project.clone().unwrap_or_else(|| "<none>".to_string())
+                ))
+                Text(content: "API key:           set".to_string())
+            }
+        }
+        .print();
+    } else {
+        println!("deployment\t{}", config.deployment_name);
+        println!("url\t{}", config.adaptive_base_url);
+        println!(
+            "default_project\t{}",
+            config.default_project.unwrap_or_default()
+        );
+    }
+    Ok(())
+}
+
+/// If no deployment is configured, prompt the user to set one up (TTY) or
+/// surface a clear error (non-TTY) before any command that needs config runs.
+fn ensure_deployment_configured() -> Result<()> {
+    let file = config::read_config_file()?;
+    if !file.deployments.is_empty() {
+        return Ok(());
+    }
+    if io::stdout().is_terminal() && io::stdin().is_terminal() {
+        element!(ErrorMessage(
+            message: "No deployment configured.".to_string()
+        ))
+        .print();
+        let answer = read_input("Set one up now?", Some("Y"), Some("[Y/n]"))?;
+        if !answer.is_empty()
+            && !answer.eq_ignore_ascii_case("y")
+            && !answer.eq_ignore_ascii_case("yes")
+        {
+            bail!("Aborted. Run `adpt deployment setup <name>` to configure.");
+        }
+        deployment_setup(None, None, None, None)
+    } else {
+        bail!("No deployment configured. Run `adpt deployment setup <name>`.");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1670,8 +1670,8 @@ fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
             config.default_project.unwrap_or_default(),
             suffix(project_note.as_ref())
         );
-        if key_note.is_some() {
-            println!("api_key\tset\t{}", key_note.unwrap());
+        if let Some(note) = key_note {
+            println!("api_key\tset\t{}", note);
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use slug::slugify;
 use std::{
     fs,
     io::{self, IsTerminal, Write},
-    os::unix::process::CommandExt,
     path::{Path, PathBuf},
     sync::Arc,
     time::SystemTime,
@@ -1517,17 +1516,34 @@ fn spawn_pinned_shell(name: &str) -> Result<()> {
         return Ok(());
     }
 
+    #[cfg(unix)]
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    #[cfg(windows)]
+    let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+
     element!(SuccessMessage(
         message: format!("Pinned shell to `{name}` (exit to leave).")
     ))
     .print();
 
-    let err = std::process::Command::new(&shell)
-        .env("ADPT_DEPLOYMENT", name)
-        .exec();
-    // exec only returns on failure.
-    Err(anyhow!("Failed to exec `{shell}`: {err}"))
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new(&shell)
+            .env("ADPT_DEPLOYMENT", name)
+            .exec();
+        // exec only returns on failure.
+        Err(anyhow!("Failed to exec `{shell}`: {err}"))
+    }
+
+    #[cfg(windows)]
+    {
+        let status = std::process::Command::new(&shell)
+            .env("ADPT_DEPLOYMENT", name)
+            .status()
+            .map_err(|e| anyhow!("Failed to spawn `{shell}`: {e}"))?;
+        std::process::exit(status.code().unwrap_or(0));
+    }
 }
 
 fn shell_escape(s: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use slug::slugify;
 use std::{
     fs,
     io::{self, IsTerminal, Write},
+    os::unix::process::CommandExt,
     path::{Path, PathBuf},
     sync::Arc,
     time::SystemTime,
@@ -213,10 +214,13 @@ enum DeploymentCommands {
         /// Deployment name. Defaults to the active deployment.
         name: Option<String>,
     },
-    /// Set the active deployment
+    /// Pin a shell to a deployment (spawns a subshell with $ADPT_DEPLOYMENT)
     Use {
         /// Deployment name to activate
         name: String,
+        /// Also persist as the file-level active deployment for fresh shells
+        #[arg(short, long)]
+        persist: bool,
     },
     /// Print just the active deployment name (for shell prompts)
     Current,
@@ -357,6 +361,8 @@ fn build_adaptive_client(base_url: Url, api_key: String) -> AdaptiveClient {
 }
 
 fn main() -> Result<()> {
+    let _ = dotenvy::dotenv();
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -1481,7 +1487,57 @@ fn deployment_setup(
         message: format!("Deployment `{name}` {action}.")
     ))
     .print();
-    Ok(())
+
+    // Drop the user into a pinned shell so they can immediately use the deployment they just set up.
+    spawn_pinned_shell(&name)
+}
+
+fn deployment_use(name: String, persist: bool) -> Result<()> {
+    let name = config::normalize_name(&name);
+    let file = config::read_config_file()?;
+    if !file.deployments.contains_key(&name) {
+        bail!("Deployment `{name}` is not configured. Run `adpt deployment setup {name}`.");
+    }
+    if persist {
+        config::set_active(&name)?;
+    }
+    spawn_pinned_shell(&name)
+}
+
+/// Spawn a new interactive shell with `$ADPT_DEPLOYMENT=<name>` exported, so
+/// every command in that shell resolves to this deployment. If the current
+/// process is already such a pinned shell (i.e. `$ADPT_DEPLOYMENT` is set),
+/// we re-exec the parent shell instead of nesting.
+///
+/// In non-TTY contexts we emit `export ADPT_DEPLOYMENT=<name>` on stdout so
+/// the caller can `eval $(adpt deployment use <name>)` in a script.
+fn spawn_pinned_shell(name: &str) -> Result<()> {
+    if !io::stdout().is_terminal() || std::env::var("ADPT_NO_SUBSHELL").is_ok() {
+        println!("export ADPT_DEPLOYMENT={}", shell_escape(name));
+        return Ok(());
+    }
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    element!(SuccessMessage(
+        message: format!("Pinned shell to `{name}` (exit to leave).")
+    ))
+    .print();
+
+    let err = std::process::Command::new(&shell)
+        .env("ADPT_DEPLOYMENT", name)
+        .exec();
+    // exec only returns on failure.
+    Err(anyhow!("Failed to exec `{shell}`: {err}"))
+}
+
+fn shell_escape(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
 }
 
 fn handle_deployment_command(
@@ -1497,14 +1553,7 @@ fn handle_deployment_command(
         } => deployment_setup(name, url, default_project, api_key),
         DeploymentCommands::List => deployment_list(),
         DeploymentCommands::Show { name } => deployment_show(name.as_deref(), deployment_override),
-        DeploymentCommands::Use { name } => {
-            config::set_active(&name)?;
-            element!(SuccessMessage(
-                message: format!("Active deployment set to `{name}`.")
-            ))
-            .print();
-            Ok(())
-        }
+        DeploymentCommands::Use { name, persist } => deployment_use(name, persist),
         DeploymentCommands::Current => deployment_current(deployment_override),
         DeploymentCommands::Remove { name, force } => {
             config::remove_deployment(&name, force)?;
@@ -1590,8 +1639,13 @@ fn deployment_show(name: Option<&str>, deployment_override: Option<&str>) -> Res
 
 fn deployment_current(deployment_override: Option<&str>) -> Result<()> {
     let file = config::read_config_file()?;
+    let env_pinned = std::env::var("ADPT_DEPLOYMENT")
+        .ok()
+        .filter(|s| !s.is_empty());
     let name = if let Some(o) = deployment_override {
         config::normalize_name(o)
+    } else if let Some(env_name) = env_pinned {
+        config::normalize_name(&env_name)
     } else if let Some(a) = file.active_deployment.clone() {
         a
     } else if file.deployments.len() == 1 {
@@ -1620,7 +1674,16 @@ fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
     let key_env = std::env::var("ADAPTIVE_API_KEY").ok();
     let project_env = std::env::var("DEFAULT_PROJECT").ok();
 
-    let deployment_note = deployment_override.map(|_| "via --deployment".to_string());
+    let deployment_env = std::env::var("ADPT_DEPLOYMENT")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let deployment_note = if deployment_override.is_some() {
+        Some("via --deployment".to_string())
+    } else {
+        deployment_env
+            .as_ref()
+            .map(|_| "via $ADPT_DEPLOYMENT".to_string())
+    };
     let url_note = url_env
         .as_ref()
         .map(|_| "via ADAPTIVE_BASE_URL".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,13 +196,13 @@ enum DeploymentCommands {
     Setup {
         /// Deployment name. If omitted, edits the active deployment.
         name: Option<String>,
-        /// Skip the dialog by passing the base URL directly
+        /// Base URL (for non-interactive setup, e.g. in CI)
         #[arg(long)]
         url: Option<Url>,
-        /// Skip the dialog by passing a default project directly
+        /// Default project (for non-interactive setup)
         #[arg(long)]
         default_project: Option<String>,
-        /// Skip the dialog by passing the API key directly
+        /// API key (for non-interactive setup)
         #[arg(long)]
         api_key: Option<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1718,6 +1718,14 @@ fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
         note.map(|n| format!("  [{}]", n)).unwrap_or_default()
     };
 
+    let deployment_overridden = deployment_note.is_some();
+    let fields_overridden = url_note.is_some() || key_note.is_some() || project_note.is_some();
+    let name_color = if deployment_overridden || fields_overridden {
+        Color::Yellow
+    } else {
+        deployment_color(&config.deployment_name)
+    };
+
     if is_tty {
         element! {
             View(flex_direction: FlexDirection::Column) {
@@ -1725,22 +1733,22 @@ fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
                     Text(content: "Active deployment: ", weight: Weight::Bold)
                     Text(
                         content: config.deployment_name.clone(),
-                        color: deployment_color(&config.deployment_name),
+                        color: name_color,
                         weight: Weight::Bold,
                     )
-                    Text(content: fmt_note(deployment_note.as_ref()), color: Color::DarkGrey)
+                    Text(content: fmt_note(deployment_note.as_ref()), color: Color::Yellow)
                 }
                 View(flex_direction: FlexDirection::Row) {
                     Text(content: format!("URL:               {}", config.adaptive_base_url))
-                    Text(content: fmt_note(url_note.as_ref()), color: Color::DarkGrey)
+                    Text(content: fmt_note(url_note.as_ref()), color: Color::Yellow)
                 }
                 View(flex_direction: FlexDirection::Row) {
                     Text(content: format!("Default project:   {}", project_value))
-                    Text(content: fmt_note(project_note.as_ref()), color: Color::DarkGrey)
+                    Text(content: fmt_note(project_note.as_ref()), color: Color::Yellow)
                 }
                 View(flex_direction: FlexDirection::Row) {
                     Text(content: "API key:           set".to_string())
-                    Text(content: fmt_note(key_note.as_ref()), color: Color::DarkGrey)
+                    Text(content: fmt_note(key_note.as_ref()), color: Color::Yellow)
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1341,7 +1341,7 @@ fn read_input(prompt: &str, default: Option<&str>, description: Option<&str>) ->
 /// Prompt for a deployment name when none was provided. Returns the resolved name.
 fn resolve_setup_target(provided: Option<String>) -> Result<(String, Option<DeploymentConfig>)> {
     let file = config::read_config_file()?;
-    let name = if let Some(name) = provided {
+    let raw = if let Some(name) = provided {
         name
     } else if let Some(active) = file.active_deployment.clone() {
         active
@@ -1356,6 +1356,19 @@ fn resolve_setup_target(provided: Option<String>) -> Result<(String, Option<Depl
         }
         entered
     };
+    let name = config::normalize_name(&raw);
+    if name.is_empty() {
+        bail!("Deployment name must contain at least one alphanumeric character");
+    }
+    if name != raw {
+        element! {
+            Text(
+                content: format!("  Using `{name}` as the deployment name."),
+                color: Color::DarkGrey,
+            )
+        }
+        .print();
+    }
     let existing = file.deployments.get(&name).cloned();
     Ok((name, existing))
 }
@@ -1537,8 +1550,8 @@ fn deployment_list() -> Result<()> {
 fn deployment_show(name: Option<&str>, deployment_override: Option<&str>) -> Result<()> {
     let file = config::read_config_file()?;
     let target = name
-        .map(str::to_string)
-        .or_else(|| deployment_override.map(str::to_string))
+        .map(config::normalize_name)
+        .or_else(|| deployment_override.map(config::normalize_name))
         .or_else(|| file.active_deployment.clone())
         .ok_or_else(|| anyhow!("No deployment specified and none active."))?;
     let cfg = file
@@ -1578,7 +1591,7 @@ fn deployment_show(name: Option<&str>, deployment_override: Option<&str>) -> Res
 fn deployment_current(deployment_override: Option<&str>) -> Result<()> {
     let file = config::read_config_file()?;
     let name = if let Some(o) = deployment_override {
-        o.to_string()
+        config::normalize_name(o)
     } else if let Some(a) = file.active_deployment.clone() {
         a
     } else if file.deployments.len() == 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1602,7 +1602,30 @@ fn deployment_current(deployment_override: Option<&str>) -> Result<()> {
 
 fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
     let config = config::read_config(deployment_override)?;
+    // read_config invoked dotenv, so env::var sees the merged environment.
+    let url_env = std::env::var("ADAPTIVE_BASE_URL").ok();
+    let key_env = std::env::var("ADAPTIVE_API_KEY").ok();
+    let project_env = std::env::var("DEFAULT_PROJECT").ok();
+
+    let deployment_note = deployment_override.map(|_| "via --deployment".to_string());
+    let url_note = url_env
+        .as_ref()
+        .map(|_| "via ADAPTIVE_BASE_URL".to_string());
+    let key_note = key_env.as_ref().map(|_| "via ADAPTIVE_API_KEY".to_string());
+    let project_note = project_env
+        .as_ref()
+        .map(|_| "via DEFAULT_PROJECT".to_string());
+
     let is_tty = io::stdout().is_terminal();
+    let project_value = config
+        .default_project
+        .clone()
+        .unwrap_or_else(|| "<none>".to_string());
+
+    let fmt_note = |note: Option<&String>| -> String {
+        note.map(|n| format!("  [{}]", n)).unwrap_or_default()
+    };
+
     if is_tty {
         element! {
             View(flex_direction: FlexDirection::Column) {
@@ -1613,23 +1636,43 @@ fn print_whoami(deployment_override: Option<&str>) -> Result<()> {
                         color: deployment_color(&config.deployment_name),
                         weight: Weight::Bold,
                     )
+                    Text(content: fmt_note(deployment_note.as_ref()), color: Color::DarkGrey)
                 }
-                Text(content: format!("URL:               {}", config.adaptive_base_url))
-                Text(content: format!(
-                    "Default project:   {}",
-                    config.default_project.clone().unwrap_or_else(|| "<none>".to_string())
-                ))
-                Text(content: "API key:           set".to_string())
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: format!("URL:               {}", config.adaptive_base_url))
+                    Text(content: fmt_note(url_note.as_ref()), color: Color::DarkGrey)
+                }
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: format!("Default project:   {}", project_value))
+                    Text(content: fmt_note(project_note.as_ref()), color: Color::DarkGrey)
+                }
+                View(flex_direction: FlexDirection::Row) {
+                    Text(content: "API key:           set".to_string())
+                    Text(content: fmt_note(key_note.as_ref()), color: Color::DarkGrey)
+                }
             }
         }
         .print();
     } else {
-        println!("deployment\t{}", config.deployment_name);
-        println!("url\t{}", config.adaptive_base_url);
+        let suffix = |n: Option<&String>| n.map(|s| format!("\t{}", s)).unwrap_or_default();
         println!(
-            "default_project\t{}",
-            config.default_project.unwrap_or_default()
+            "deployment\t{}{}",
+            config.deployment_name,
+            suffix(deployment_note.as_ref())
         );
+        println!(
+            "url\t{}{}",
+            config.adaptive_base_url,
+            suffix(url_note.as_ref())
+        );
+        println!(
+            "default_project\t{}{}",
+            config.default_project.unwrap_or_default(),
+            suffix(project_note.as_ref())
+        );
+        if key_note.is_some() {
+            println!("api_key\tset\t{}", key_note.unwrap());
+        }
     }
     Ok(())
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::sync::LazyLock;
 use termwiz::escape::osc::OperatingSystemCommand;
 pub use termwiz::escape::osc::Progress;
@@ -16,7 +17,7 @@ static SUPPORTS_ADVANCED_FEATURES: LazyLock<bool> = LazyLock::new(|| {
 });
 
 fn supports_advanced_features() -> bool {
-    *SUPPORTS_ADVANCED_FEATURES
+    *SUPPORTS_ADVANCED_FEATURES && std::io::stdout().is_terminal()
 }
 
 pub struct TitleGuard {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -678,23 +678,55 @@ pub fn Spinner(props: &SpinnerProps, mut hooks: Hooks) -> impl Into<AnyElement<'
 }
 
 #[derive(Default, Props)]
-pub struct ConfigHeaderProps {}
+pub struct ConfigHeaderProps {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+}
 
 #[component]
-pub fn ConfigHeader(_props: &ConfigHeaderProps) -> impl Into<AnyElement<'static>> {
+pub fn ConfigHeader(props: &ConfigHeaderProps) -> impl Into<AnyElement<'static>> {
+    let title = props
+        .title
+        .clone()
+        .unwrap_or_else(|| "⚙️  Configure adpt".to_string());
+    let subtitle = props
+        .subtitle
+        .clone()
+        .unwrap_or_else(|| "Set up your Adaptive CLI configuration".to_string());
     element! {
         View(flex_direction: FlexDirection::Column, margin_bottom: 2) {
             Text(
-                content: "⚙️  Configure adpt",
+                content: title,
                 weight: Weight::Bold,
                 color: Color::Blue
             )
             Text(
-                content: "Set up your Adaptive CLI configuration",
+                content: subtitle,
                 color: Color::DarkGrey
             )
         }
     }
+}
+
+/// Stable color for a deployment name. Uses FNV-1a so the same name always
+/// renders in the same color across invocations and machines.
+pub fn deployment_color(name: &str) -> Color {
+    const PALETTE: [Color; 8] = [
+        Color::Cyan,
+        Color::Blue,
+        Color::Magenta,
+        Color::Yellow,
+        Color::DarkCyan,
+        Color::DarkBlue,
+        Color::DarkMagenta,
+        Color::DarkYellow,
+    ];
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in name.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    PALETTE[(hash as usize) % PALETTE.len()]
 }
 
 #[derive(Default, Props)]


### PR DESCRIPTION
## Summary
- Replace the flat single-deployment config with named deployments (`[deployments.<name>]` + `active_deployment`); per-deployment API keys stored under `Adaptive:<name>` in the OS keyring.
- New surface: `adpt deployment {setup,list,show,use,current,remove}`, `adpt whoami`, and a global `--deployment <name>` override. Drops `adpt configure` and `adpt set-api-key` (folded into `deployment setup`).
- Kubie-style switching: `adpt deployment use <name>` spawns a subshell with `$ADPT_DEPLOYMENT` exported so each terminal pins independently; `--persist` (and `setup`) also writes `active_deployment` to the config file for new shells. Resolution order per command: `--deployment` flag → `$ADPT_DEPLOYMENT` → file's `active_deployment`.
- `.env` overrides apply on top of the resolved deployment, including `ADPT_DEPLOYMENT` itself (loaded via `dotenvy` at startup) so a repo can pin its own deployment.
- Legacy flat configs auto-migrate into `[deployments.default]` (file rewrite + keyring rename) on first run after upgrade.

Closes FE-26