### PR TITLE
Bundle third-party license notices with releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Work around intermittent "HTTP2 framing layer" errors when cargo refreshes
+  # the crates.io index in CI.
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Work around intermittent "HTTP2 framing layer" errors when cargo refreshes
-  # the crates.io index in CI.
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_NET_RETRY: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,25 @@ jobs:
         with:
           name: adpt-macos
           path: target/debug/adpt
+
+  third-party-licenses:
+    name: Third-party licenses
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-about
+        run: cargo install cargo-about --locked --features cli
+
+      - name: Generate third-party licenses
+        run: scripts/generate-third-party-licenses.sh
+
+      - name: Upload third-party licenses
+        uses: actions/upload-artifact@v7
+        with:
+          name: third-party-licenses
+          path: THIRD_PARTY_LICENSES.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Work around intermittent "HTTP2 framing layer" errors when cargo refreshes
+  # the crates.io index in CI.
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   build_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Work around intermittent "HTTP2 framing layer" errors when cargo refreshes
-  # the crates.io index in CI.
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_NET_RETRY: 10
 
@@ -68,8 +66,6 @@ jobs:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
-      # Generate before building so the notices get embedded into the binary
-      # (build.rs picks up THIRD_PARTY_LICENSES.txt for `adpt --licenses`).
       - name: Generate third-party licenses
         shell: bash
         run: scripts/generate-third-party-licenses.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
         run: cargo install cargo-generate-rpm
 
       - name: Install cargo-about
-        if: matrix.os == 'ubuntu-latest'
         run: cargo install cargo-about --locked --features cli
 
       - name: Cache cargo registry
@@ -65,6 +64,12 @@ jobs:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
+      # Generate before building so the notices get embedded into the binary
+      # (build.rs picks up THIRD_PARTY_LICENSES.txt for `adpt --licenses`).
+      - name: Generate third-party licenses
+        shell: bash
+        run: scripts/generate-third-party-licenses.sh
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 
@@ -72,10 +77,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run:
           strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
-
-      - name: Generate third-party licenses
-        if: matrix.os == 'ubuntu-latest'
-        run: scripts/generate-third-party-licenses.sh
 
       - name: Build RPM
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo install cargo-generate-rpm
 
+      - name: Install cargo-about
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo install cargo-about --locked --features cli
+
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -68,6 +72,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run:
           strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+
+      - name: Generate third-party licenses
+        if: matrix.os == 'ubuntu-latest'
+        run: scripts/generate-third-party-licenses.sh
 
       - name: Build RPM
         if: matrix.os == 'ubuntu-latest'
@@ -90,6 +98,14 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: "*.rpm"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload third-party licenses
+        if: matrix.os == 'ubuntu-latest'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: THIRD_PARTY_LICENSES.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 
-# Generated per-build third-party attribution (bundled with release artifacts)
 /THIRD_PARTY_LICENSES.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Generated per-build third-party attribution (bundled with release artifacts)
+/THIRD_PARTY_LICENSES.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,5 @@ typed-path = "0.12.3"
 [package.metadata.generate-rpm]
 assets = [
     { source = "target/x86_64-unknown-linux-gnu/release/adpt", dest = "/usr/bin/adpt", mode = "755" },
+    { source = "THIRD_PARTY_LICENSES.txt", dest = "/usr/share/doc/adpt/THIRD_PARTY_LICENSES.txt", mode = "644" },
 ]

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -43,7 +43,7 @@ This document contains the help content for the `adpt` command-line program.
 
 A tool interacting with the Adaptive platform
 
-**Usage:** `adpt [OPTIONS] <COMMAND>`
+**Usage:** `adpt [OPTIONS] [COMMAND]`
 
 ###### **Subcommands:**
 
@@ -65,6 +65,7 @@ A tool interacting with the Adaptive platform
 ###### **Options:**
 
 * `--deployment <DEPLOYMENT>` — Use a specific deployment for this invocation, overriding the active one
+* `--licenses` — Print the third-party license notices for adpt's dependencies and exit
 
 
 

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,11 @@
+{{#each licenses}}
+--------------------------------------------------------------------------------
+License: {{{name}}} ({{{id}}})
+Used by:
+{{#each used_by}}
+  - {{{crate.name}}}@{{{crate.version}}}
+{{/each}}
+
+{{{text}}}
+
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,36 @@
+# cargo-about config for the third-party attribution bundled with adpt releases.
+# The shipped binary statically links the crate closure below, so distributing it
+# distributes that object code — their license terms must travel with the artifact.
+# Generated via scripts/generate-third-party-licenses.sh; the output is never committed.
+accepted = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "MPL-2.0",
+    "BSL-1.0",
+    "OpenSSL",
+    "CDLA-Permissive-2.0",
+    "WTFPL",
+]
+
+# adpt ships binaries for these targets (see .github/workflows/release.yml).
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+workarounds = ["ring", "rustls"]
+
+[private]
+ignore = true

--- a/about.toml
+++ b/about.toml
@@ -1,7 +1,3 @@
-# cargo-about config for the third-party attribution bundled with adpt releases.
-# The shipped binary statically links the crate closure below, so distributing it
-# distributes that object code — their license terms must travel with the artifact.
-# Generated via scripts/generate-third-party-licenses.sh; the output is never committed.
 accepted = [
     "MIT",
     "MIT-0",
@@ -22,7 +18,6 @@ accepted = [
     "WTFPL",
 ]
 
-# adpt ships binaries for these targets (see .github/workflows/release.yml).
 targets = [
     "x86_64-unknown-linux-gnu",
     "aarch64-apple-darwin",

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,5 @@
 use std::{env, fs, path::Path};
 
-// Embeds the third-party license notices into the binary so `adpt --licenses`
-// works regardless of how adpt was installed (brew, winget, cargo install, ...).
-//
-// The notices file is generated per-build by scripts/generate-third-party-licenses.sh
-// and is gitignored. Release CI runs that script before `cargo build`, so the real
-// notices get baked in. For ordinary dev builds (and `cargo install` from crates.io)
-// the file is absent, so we embed a short placeholder that points at the release page.
 fn main() {
     println!("cargo:rerun-if-changed=THIRD_PARTY_LICENSES.txt");
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::{env, fs, path::Path};
+
+// Embeds the third-party license notices into the binary so `adpt --licenses`
+// works regardless of how adpt was installed (brew, winget, cargo install, ...).
+//
+// The notices file is generated per-build by scripts/generate-third-party-licenses.sh
+// and is gitignored. Release CI runs that script before `cargo build`, so the real
+// notices get baked in. For ordinary dev builds (and `cargo install` from crates.io)
+// the file is absent, so we embed a short placeholder that points at the release page.
+fn main() {
+    println!("cargo:rerun-if-changed=THIRD_PARTY_LICENSES.txt");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let src = Path::new(&manifest_dir).join("THIRD_PARTY_LICENSES.txt");
+    let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("third_party_licenses.txt");
+
+    let content = fs::read_to_string(&src).unwrap_or_else(|_| {
+        "Third-party license notices are generated at release build time and are not \
+         present in this build.\n\nDownload the full THIRD_PARTY_LICENSES.txt for a \
+         release from https://github.com/adaptive-ml/adpt/releases, or run \
+         scripts/generate-third-party-licenses.sh from a checkout to produce it.\n"
+            .to_string()
+    });
+
+    fs::write(&dst, content).unwrap();
+}

--- a/scripts/generate-third-party-licenses.sh
+++ b/scripts/generate-third-party-licenses.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Generates THIRD_PARTY_LICENSES.txt: the third-party OSS licenses for the Rust
+# crates STATICALLY LINKED into the shipped `adpt` binary. Because the release
+# binary links its whole dependency closure, distributing it distributes that
+# object code — so the dependencies' license terms must travel with the artifact.
+#
+# Output is regenerated per build and never committed (see .gitignore).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:-$ROOT/THIRD_PARTY_LICENSES.txt}"
+
+log() { echo "[third-party-licenses] $*"; }
+
+if ! command -v cargo-about >/dev/null 2>&1; then
+    if [[ -x "$HOME/.cargo/bin/cargo-about" ]]; then
+        export PATH="$HOME/.cargo/bin:$PATH"
+    else
+        echo "ERROR: cargo-about not found." >&2
+        echo "Install it with: cargo install cargo-about --locked --features cli (or cargo binstall cargo-about)" >&2
+        exit 1
+    fi
+fi
+log "using cargo-about $(cargo-about --version)"
+
+# `about.toml` carries the accepted-license allowlist and the shipped targets;
+# `about.hbs` is the plain-text template. `[private] ignore = true` drops the
+# first-party `adpt` crate so only third-party dependencies are emitted. --fail
+# aborts if any crate's license is missing or outside the allowlist.
+RAW="$(mktemp)"
+trap 'rm -f "$RAW"' EXIT
+log "generating licenses for the adpt dependency closure"
+cargo about generate --locked --fail -c "$ROOT/about.toml" -o "$RAW" "$ROOT/about.hbs"
+log "done ($(grep -c '^License:' "$RAW") license blocks)"
+
+{
+    cat <<EOF
+================================================================================
+adpt - Third-Party Software Notices
+================================================================================
+Generated at build time on $(date -u +"%Y-%m-%dT%H:%M:%SZ").
+
+The adpt binary statically links the third-party crates listed below. Their
+license terms are reproduced here, as required, because their object code is
+distributed as part of this binary.
+
+EOF
+    cat "$RAW"
+} > "$OUT"
+log "wrote $OUT ($(du -h "$OUT" | cut -f1 | tr -d ' '))"

--- a/scripts/generate-third-party-licenses.sh
+++ b/scripts/generate-third-party-licenses.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
-# Generates THIRD_PARTY_LICENSES.txt: the third-party OSS licenses for the Rust
-# crates STATICALLY LINKED into the shipped `adpt` binary. Because the release
-# binary links its whole dependency closure, distributing it distributes that
-# object code — so the dependencies' license terms must travel with the artifact.
-#
-# Output is regenerated per build and never committed (see .gitignore).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -23,10 +17,6 @@ if ! command -v cargo-about >/dev/null 2>&1; then
 fi
 log "using cargo-about $(cargo-about --version)"
 
-# `about.toml` carries the accepted-license allowlist and the shipped targets;
-# `about.hbs` is the plain-text template. `[private] ignore = true` drops the
-# first-party `adpt` crate so only third-party dependencies are emitted. --fail
-# aborts if any crate's license is missing or outside the allowlist.
 RAW="$(mktemp)"
 trap 'rm -f "$RAW"' EXIT
 log "generating licenses for the adpt dependency closure"

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,13 +50,20 @@ const DEFAULT_ADAPTIVE_BASE_URL: &str = "https://app.adaptive.ml";
 #[command(about = "A tool interacting with the Adaptive platform")]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
     /// Use a specific deployment for this invocation, overriding the active one
     #[arg(long, global = true)]
     deployment: Option<String>,
+    /// Print the third-party license notices for adpt's dependencies and exit
+    #[arg(long)]
+    licenses: bool,
     #[arg(long, hide = true)]
     markdown_help: bool,
 }
+
+/// Third-party license notices, embedded at build time (see build.rs).
+const THIRD_PARTY_LICENSES: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/third_party_licenses.txt"));
 
 #[derive(Args)]
 struct RunArgs {
@@ -372,11 +379,20 @@ fn main() -> Result<()> {
         clap_markdown::print_help_markdown::<Cli>();
         return Ok(());
     }
-    let _title_guard = TitleGuard::new(&format!("adpt - {}", cli.command.name()));
+    if cli.licenses {
+        print!("{THIRD_PARTY_LICENSES}");
+        return Ok(());
+    }
+    let Some(command) = cli.command else {
+        Cli::command().print_help()?;
+        println!();
+        return Ok(());
+    };
+    let _title_guard = TitleGuard::new(&format!("adpt - {}", command.name()));
 
     let deployment_override = cli.deployment.clone();
     rt.block_on(async {
-        match cli.command {
+        match command {
             Commands::Deployment { command } => {
                 handle_deployment_command(command, deployment_override.as_deref())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ struct Cli {
     markdown_help: bool,
 }
 
-/// Third-party license notices, embedded at build time (see build.rs).
 const THIRD_PARTY_LICENSES: &str =
     include_str!(concat!(env!("OUT_DIR"), "/third_party_licenses.txt"));
 


### PR DESCRIPTION
The release binary statically links all its Rust dependencies, so we need to ship their licenses alongside it.

A script runs cargo-about to collect every dependency's license into a single THIRD_PARTY_LICENSES.txt, generated at build time (not committed). It is:
- embedded into the binary and printable with `adpt --licenses`, so it works no matter how adpt was installed (brew, winget, cargo install, direct download)
- attached to the GitHub release as a downloadable file
- included in the RPM under /usr/share/doc/adpt

CI generates it on every commit and uploads it as an artifact, which also fails the build if a dependency's license isn't in the allowlist.

Same idea as what we did in the adaptive repo, scoped to this CLI.